### PR TITLE
kv-transfer: core trace I/O, KL utilities, and build system

### DIFF
--- a/kv-transfer/CMakeLists.txt
+++ b/kv-transfer/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.14)
+project(kv-transfer LANGUAGES C CXX)
+
+set(LLAMA_CPP_DIR "$ENV{LLAMA_CPP_DIR}" CACHE PATH "Path to llama.cpp source tree")
+if(NOT LLAMA_CPP_DIR)
+    message(FATAL_ERROR "LLAMA_CPP_DIR is not set. Pass -DLLAMA_CPP_DIR=... or set the LLAMA_CPP_DIR environment variable.")
+endif()
+
+if(NOT EXISTS "${LLAMA_CPP_DIR}/CMakeLists.txt")
+    message(FATAL_ERROR "llama.cpp not found at ${LLAMA_CPP_DIR}")
+endif()
+
+set(LLAMA_BUILD_COMMON ON CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
+
+add_subdirectory(${LLAMA_CPP_DIR} ${CMAKE_CURRENT_BINARY_DIR}/llama.cpp)
+
+find_package(Threads REQUIRED)
+
+add_executable(kv-transfer
+    src/main.cpp
+    src/trace_io.cpp
+    src/ref.cpp
+    src/target.cpp
+    src/handoff.cpp
+    src/compare.cpp
+    src/decay.cpp
+)
+
+target_include_directories(kv-transfer PRIVATE
+    ${LLAMA_CPP_DIR}/include
+    ${LLAMA_CPP_DIR}/common
+)
+
+target_link_libraries(kv-transfer PRIVATE
+    common
+    llama
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+target_compile_features(kv-transfer PRIVATE cxx_std_17)

--- a/kv-transfer/src/compare.cpp
+++ b/kv-transfer/src/compare.cpp
@@ -1,0 +1,3 @@
+#include "compare.h"
+#include <cstdio>
+int cmd_compare(int, char **) { fprintf(stderr, "compare: not yet implemented\n"); return 1; }

--- a/kv-transfer/src/compare.h
+++ b/kv-transfer/src/compare.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int cmd_compare(int argc, char ** argv);

--- a/kv-transfer/src/decay.cpp
+++ b/kv-transfer/src/decay.cpp
@@ -1,0 +1,3 @@
+#include "decay.h"
+#include <cstdio>
+int cmd_decay(int, char **) { fprintf(stderr, "decay: not yet implemented\n"); return 1; }

--- a/kv-transfer/src/decay.h
+++ b/kv-transfer/src/decay.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int cmd_decay(int argc, char ** argv);

--- a/kv-transfer/src/handoff.cpp
+++ b/kv-transfer/src/handoff.cpp
@@ -1,0 +1,3 @@
+#include "handoff.h"
+#include <cstdio>
+int cmd_handoff(int, char **) { fprintf(stderr, "handoff: not yet implemented\n"); return 1; }

--- a/kv-transfer/src/handoff.h
+++ b/kv-transfer/src/handoff.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int cmd_handoff(int argc, char ** argv);

--- a/kv-transfer/src/kl_utils.h
+++ b/kv-transfer/src/kl_utils.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+// Compute log-softmax with temperature scaling applied to logits.
+inline void log_softmax_temp(const float * logits, int32_t n_vocab, double temp,
+                             std::vector<double> & out) {
+    out.resize(n_vocab);
+
+    double inv_t = 1.0 / temp;
+    double max_val = (double)logits[0] * inv_t;
+    for (int32_t j = 1; j < n_vocab; j++) {
+        double v = (double)logits[j] * inv_t;
+        if (v > max_val) max_val = v;
+    }
+
+    double sum_exp = 0.0;
+    for (int32_t j = 0; j < n_vocab; j++) {
+        sum_exp += exp((double)logits[j] * inv_t - max_val);
+    }
+    double log_sum = log(sum_exp);
+
+    for (int32_t j = 0; j < n_vocab; j++) {
+        out[j] = (double)logits[j] * inv_t - max_val - log_sum;
+    }
+}
+
+// KL(P || Q) = sum_j P[j] * (log P[j] - log Q[j])
+inline double kl_divergence(const std::vector<double> & log_p,
+                            const std::vector<double> & log_q, int32_t n_vocab) {
+    double kl = 0.0;
+    for (int32_t j = 0; j < n_vocab; j++) {
+        double p_j = exp(log_p[j]);
+        if (p_j > 1e-30) {
+            kl += p_j * (log_p[j] - log_q[j]);
+        }
+    }
+    return kl;
+}
+
+inline int32_t argmax(const float * v, int32_t n) {
+    int32_t best = 0;
+    for (int32_t j = 1; j < n; j++) {
+        if (v[j] > v[best]) best = j;
+    }
+    return best;
+}

--- a/kv-transfer/src/main.cpp
+++ b/kv-transfer/src/main.cpp
@@ -1,0 +1,50 @@
+#include "ref.h"
+#include "target.h"
+#include "handoff.h"
+#include "compare.h"
+#include "decay.h"
+
+#include <cstdio>
+#include <cstring>
+
+static void print_usage(const char * prog) {
+    fprintf(stderr,
+        "Usage: %s <command> [options]\n"
+        "\n"
+        "Commands:\n"
+        "  ref      Run reference model (prompt + generation), save logits\n"
+        "  target   Run target model on existing tokens, save logits\n"
+        "  handoff  Process prompt with ref model, transfer KV, generate with target\n"
+        "  compare  Compare two .bin files (KL divergence + top-1 agreement)\n"
+        "  decay    Analyze KL decay across generation position\n",
+        prog);
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    const char * cmd = argv[1];
+
+    if (strcmp(cmd, "ref") == 0) {
+        return cmd_ref(argc - 1, argv + 1);
+    }
+    if (strcmp(cmd, "target") == 0) {
+        return cmd_target(argc - 1, argv + 1);
+    }
+    if (strcmp(cmd, "handoff") == 0) {
+        return cmd_handoff(argc - 1, argv + 1);
+    }
+    if (strcmp(cmd, "compare") == 0) {
+        return cmd_compare(argc - 1, argv + 1);
+    }
+    if (strcmp(cmd, "decay") == 0) {
+        return cmd_decay(argc - 1, argv + 1);
+    }
+
+    fprintf(stderr, "Unknown command: %s\n\n", cmd);
+    print_usage(argv[0]);
+    return 1;
+}

--- a/kv-transfer/src/ref.cpp
+++ b/kv-transfer/src/ref.cpp
@@ -1,0 +1,3 @@
+#include "ref.h"
+#include <cstdio>
+int cmd_ref(int, char **) { fprintf(stderr, "ref: not yet implemented\n"); return 1; }

--- a/kv-transfer/src/ref.h
+++ b/kv-transfer/src/ref.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int cmd_ref(int argc, char ** argv);

--- a/kv-transfer/src/target.cpp
+++ b/kv-transfer/src/target.cpp
@@ -1,0 +1,3 @@
+#include "target.h"
+#include <cstdio>
+int cmd_target(int, char **) { fprintf(stderr, "target: not yet implemented\n"); return 1; }

--- a/kv-transfer/src/target.h
+++ b/kv-transfer/src/target.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int cmd_target(int argc, char ** argv);

--- a/kv-transfer/src/trace_io.cpp
+++ b/kv-transfer/src/trace_io.cpp
@@ -1,0 +1,211 @@
+#include "trace_io.h"
+
+#include <cstdio>
+#include <cstring>
+
+// --- v3 binary layout ---
+//
+// Global header (72 bytes):
+//   [0..7]   magic "qmlogits"
+//   [8..11]  version (uint32 = 3)
+//   [12..15] n_vocab (int32)
+//   [16..19] n_prompts (int32)
+//   [20..23] reserved (int32, zero)
+//   [24..27] temp (float)
+//   [28..31] top_p (float)
+//   [32..35] top_k (int32)
+//   [36..39] seed (uint32)
+//   [40..71] reserved (28 bytes, zero)
+//
+// Per-prompt section (repeated n_prompts times):
+//   path_len (int32) + path bytes
+//   n_tokens (int32)
+//   n_prompt (int32)
+//   tokens   (int32 * n_tokens)
+//   logits   (float * (n_tokens - 1) * n_vocab)
+
+static constexpr size_t HEADER_SIZE = 72;
+
+bool trace_write(const std::string & path, const trace_file & f) {
+    FILE * fp = fopen(path.c_str(), "wb");
+    if (!fp) {
+        fprintf(stderr, "trace_write: cannot open '%s'\n", path.c_str());
+        return false;
+    }
+
+    // global header
+    fwrite(TRACE_MAGIC, 1, 8, fp);
+
+    uint32_t version = TRACE_VERSION;
+    fwrite(&version,      4, 1, fp);
+    fwrite(&f.n_vocab,    4, 1, fp);
+    fwrite(&f.n_prompts,  4, 1, fp);
+
+    int32_t reserved_i32 = 0;
+    fwrite(&reserved_i32, 4, 1, fp);
+
+    fwrite(&f.temp,       4, 1, fp);
+    fwrite(&f.top_p,      4, 1, fp);
+    fwrite(&f.top_k,      4, 1, fp);
+    fwrite(&f.seed,       4, 1, fp);
+
+    char reserved[28] = {};
+    fwrite(reserved, 1, 28, fp);
+
+    // prompt sections
+    for (const auto & p : f.prompts) {
+        int32_t path_len = (int32_t)p.path.size();
+        fwrite(&path_len, 4, 1, fp);
+        if (path_len > 0) {
+            fwrite(p.path.data(), 1, path_len, fp);
+        }
+
+        fwrite(&p.n_tokens, 4, 1, fp);
+        fwrite(&p.n_prompt, 4, 1, fp);
+        fwrite(p.tokens.data(), 4, p.n_tokens, fp);
+
+        const size_t n_logit_floats = (size_t)(p.n_tokens - 1) * f.n_vocab;
+        fwrite(p.logits.data(), 4, n_logit_floats, fp);
+    }
+
+    fclose(fp);
+    return true;
+}
+
+// --- reader helpers ---
+
+struct raw_header {
+    int32_t  n_vocab;
+    int32_t  n_prompts;
+    float    temp;
+    float    top_p;
+    int32_t  top_k;
+    uint32_t seed;
+};
+
+static bool read_global_header(FILE * fp, raw_header & rh) {
+    char magic[8];
+    if (fread(magic, 1, 8, fp) != 8 || memcmp(magic, TRACE_MAGIC, 8) != 0) {
+        fprintf(stderr, "trace_read: bad magic\n");
+        return false;
+    }
+
+    uint32_t version;
+    if (fread(&version, 4, 1, fp) != 1) return false;
+    if (version != TRACE_VERSION) {
+        fprintf(stderr, "trace_read: unsupported version %u (expected %u)\n", version, TRACE_VERSION);
+        return false;
+    }
+
+    if (fread(&rh.n_vocab,    4, 1, fp) != 1) return false;
+    if (fread(&rh.n_prompts,  4, 1, fp) != 1) return false;
+
+    // skip reserved int32
+    if (fseek(fp, 4, SEEK_CUR) != 0) return false;
+
+    if (fread(&rh.temp,       4, 1, fp) != 1) return false;
+    if (fread(&rh.top_p,      4, 1, fp) != 1) return false;
+    if (fread(&rh.top_k,      4, 1, fp) != 1) return false;
+    if (fread(&rh.seed,       4, 1, fp) != 1) return false;
+
+    // skip 28 bytes reserved
+    if (fseek(fp, 28, SEEK_CUR) != 0) return false;
+
+    return true;
+}
+
+static bool read_path(FILE * fp, std::string & path) {
+    int32_t path_len = 0;
+    if (fread(&path_len, 4, 1, fp) != 1) return false;
+    if (path_len > 0) {
+        path.resize(path_len);
+        if ((int32_t)fread(&path[0], 1, path_len, fp) != path_len) return false;
+    } else {
+        path.clear();
+    }
+    return true;
+}
+
+// --- public API ---
+
+bool trace_read(const std::string & path, trace_file & f) {
+    FILE * fp = fopen(path.c_str(), "rb");
+    if (!fp) {
+        fprintf(stderr, "trace_read: cannot open '%s'\n", path.c_str());
+        return false;
+    }
+
+    raw_header rh;
+    if (!read_global_header(fp, rh)) { fclose(fp); return false; }
+
+    f.version    = TRACE_VERSION;
+    f.n_vocab    = rh.n_vocab;
+    f.n_prompts  = rh.n_prompts;
+    f.temp       = rh.temp;
+    f.top_p      = rh.top_p;
+    f.top_k      = rh.top_k;
+    f.seed       = rh.seed;
+    f.prompts.resize(f.n_prompts);
+
+    for (int32_t i = 0; i < f.n_prompts; i++) {
+        auto & p = f.prompts[i];
+        if (!read_path(fp, p.path)) { fclose(fp); return false; }
+        if (fread(&p.n_tokens, 4, 1, fp) != 1) { fclose(fp); return false; }
+        if (fread(&p.n_prompt, 4, 1, fp) != 1) { fclose(fp); return false; }
+
+        p.tokens.resize(p.n_tokens);
+        if ((int32_t)fread(p.tokens.data(), 4, p.n_tokens, fp) != p.n_tokens) {
+            fprintf(stderr, "trace_read: truncated tokens in prompt %d\n", i);
+            fclose(fp); return false;
+        }
+
+        const size_t n_logit_floats = (size_t)(p.n_tokens - 1) * rh.n_vocab;
+        p.logits.resize(n_logit_floats);
+        if (fread(p.logits.data(), 4, n_logit_floats, fp) != n_logit_floats) {
+            fprintf(stderr, "trace_read: truncated logits in prompt %d\n", i);
+            fclose(fp); return false;
+        }
+    }
+
+    fclose(fp);
+    return true;
+}
+
+bool trace_read_tokens(const std::string & path, trace_file & f) {
+    FILE * fp = fopen(path.c_str(), "rb");
+    if (!fp) {
+        fprintf(stderr, "trace_read_tokens: cannot open '%s'\n", path.c_str());
+        return false;
+    }
+
+    raw_header rh;
+    if (!read_global_header(fp, rh)) { fclose(fp); return false; }
+
+    f.version    = TRACE_VERSION;
+    f.n_vocab    = rh.n_vocab;
+    f.n_prompts  = rh.n_prompts;
+    f.temp       = rh.temp;
+    f.top_p      = rh.top_p;
+    f.top_k      = rh.top_k;
+    f.seed       = rh.seed;
+    f.prompts.resize(f.n_prompts);
+
+    for (int32_t i = 0; i < f.n_prompts; i++) {
+        auto & p = f.prompts[i];
+        if (!read_path(fp, p.path)) { fclose(fp); return false; }
+        if (fread(&p.n_tokens, 4, 1, fp) != 1) { fclose(fp); return false; }
+        if (fread(&p.n_prompt, 4, 1, fp) != 1) { fclose(fp); return false; }
+
+        p.tokens.resize(p.n_tokens);
+        if ((int32_t)fread(p.tokens.data(), 4, p.n_tokens, fp) != p.n_tokens) {
+            fprintf(stderr, "trace_read_tokens: truncated tokens in prompt %d\n", i);
+            fclose(fp); return false;
+        }
+
+        const size_t logit_bytes = (size_t)(p.n_tokens - 1) * rh.n_vocab * 4;
+        if (fseek(fp, (long)logit_bytes, SEEK_CUR) != 0) { fclose(fp); return false; }
+    }
+
+    fclose(fp);
+    return true;
+}

--- a/kv-transfer/src/trace_io.h
+++ b/kv-transfer/src/trace_io.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+static constexpr char     TRACE_MAGIC[]   = "qmlogits";
+static constexpr uint32_t TRACE_VERSION   = 3;
+
+// Per-prompt data section.
+struct trace_entry {
+    std::string          path;              // source file path (e.g. "math/01.txt")
+    int32_t              n_tokens = 0;      // total tokens (prompt + generated)
+    int32_t              n_prompt = 0;      // prompt-only token count
+    std::vector<int32_t> tokens;            // [n_tokens]
+    std::vector<float>   logits;            // [(n_tokens - 1) * n_vocab]
+};
+
+// Multi-prompt file.
+struct trace_file {
+    // global header fields
+    uint32_t version    = TRACE_VERSION;
+    int32_t  n_vocab    = 0;
+    int32_t  n_prompts  = 0;
+    float    temp       = 0.0f;
+    float    top_p      = 0.0f;
+    int32_t  top_k      = 0;
+    uint32_t seed       = 0;
+    // per-prompt data
+    std::vector<trace_entry> prompts;
+};
+
+// Write a multi-prompt .bin file (v3). Returns true on success.
+bool trace_write(const std::string & path, const trace_file & f);
+
+// Read a v3 .bin file. Returns true on success.
+bool trace_read(const std::string & path, trace_file & f);
+
+// Read only the header + tokens for all prompts (skip logits). Returns true on success.
+bool trace_read_tokens(const std::string & path, trace_file & f);


### PR DESCRIPTION
Foundation for the kv-transfer experiment tool. Includes:

- CMakeLists.txt: builds against llama.cpp source tree via LLAMA_CPP_DIR
- trace_io.{cpp,h}: binary trace format (v3) for saving/loading token sequences with full logit vectors
- kl_utils.h: KL divergence, log-softmax, top-k/top-p truncation
- main.cpp: subcommand dispatcher (ref/target/handoff/compare/decay)
- Stub implementations for all subcommands (to be filled in next PRs)