### PR TITLE
kv-transfer: implement ref and target subcommands

### DIFF
--- a/kv-transfer/src/ref.cpp
+++ b/kv-transfer/src/ref.cpp
@@ -1,3 +1,235 @@
 #include "ref.h"
+#include "trace_io.h"
+
+#include "llama.h"
+#include "common.h"
+
+#include <algorithm>
 #include <cstdio>
-int cmd_ref(int, char **) { fprintf(stderr, "ref: not yet implemented\n"); return 1; }
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+struct ref_params {
+    std::string model_path;
+    std::string prompt;
+    std::string output_path = "ref.bin";
+    int32_t     n_predict    = 256;
+    float       temp         = 1.0f;
+    float       top_p        = 0.95f;
+    int32_t     top_k        = 40;
+    uint32_t    seed         = 42;
+    int32_t     n_gpu_layers = 99;
+    int32_t     n_ctx        = 2048;
+    bool        no_chat      = false;
+};
+
+static bool parse_args(int argc, char ** argv, ref_params & params) {
+    for (int i = 1; i < argc; i++) {
+        const char * arg = argv[i];
+        if (strcmp(arg, "-m") == 0 && i + 1 < argc) {
+            params.model_path = argv[++i];
+        } else if (strcmp(arg, "-p") == 0 && i + 1 < argc) {
+            params.prompt = argv[++i];
+        } else if (strcmp(arg, "-o") == 0 && i + 1 < argc) {
+            params.output_path = argv[++i];
+        } else if (strcmp(arg, "-n") == 0 && i + 1 < argc) {
+            params.n_predict = atoi(argv[++i]);
+        } else if (strcmp(arg, "--temp") == 0 && i + 1 < argc) {
+            params.temp = atof(argv[++i]);
+        } else if (strcmp(arg, "--top-p") == 0 && i + 1 < argc) {
+            params.top_p = atof(argv[++i]);
+        } else if (strcmp(arg, "--top-k") == 0 && i + 1 < argc) {
+            params.top_k = atoi(argv[++i]);
+        } else if (strcmp(arg, "--seed") == 0 && i + 1 < argc) {
+            params.seed = (uint32_t)atoi(argv[++i]);
+        } else if (strcmp(arg, "-ngl") == 0 && i + 1 < argc) {
+            params.n_gpu_layers = atoi(argv[++i]);
+        } else if (strcmp(arg, "-c") == 0 && i + 1 < argc) {
+            params.n_ctx = atoi(argv[++i]);
+        } else if (strcmp(arg, "--no-chat") == 0) {
+            params.no_chat = true;
+        } else {
+            fprintf(stderr, "ref: unknown argument '%s'\n", arg);
+            return false;
+        }
+    }
+    if (params.model_path.empty() || params.prompt.empty()) {
+        fprintf(stderr, "Usage: kv-transfer ref -m <model> -p <prompt> [options]\n"
+                        "  -o <path>     output file (default: ref.bin)\n"
+                        "  -n <int>      tokens to generate (default: 256)\n"
+                        "  --temp <f>    temperature (default: 1.0)\n"
+                        "  --top-p <f>   top-p (default: 0.95)\n"
+                        "  --top-k <int> top-k (default: 40)\n"
+                        "  --seed <int>  RNG seed (default: 42)\n"
+                        "  -ngl <int>    GPU layers (default: 99)\n"
+                        "  -c <int>      context size (default: 2048)\n"
+                        "  --no-chat     skip chat template formatting\n");
+        return false;
+    }
+    return true;
+}
+
+int cmd_ref(int argc, char ** argv) {
+    ref_params params;
+    if (!parse_args(argc, argv, params)) return 1;
+
+    ggml_backend_load_all();
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.n_gpu_layers = params.n_gpu_layers;
+
+    llama_model * model = llama_model_load_from_file(params.model_path.c_str(), model_params);
+    if (!model) {
+        fprintf(stderr, "ref: failed to load model '%s'\n", params.model_path.c_str());
+        return 1;
+    }
+
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+
+    // apply chat template
+    std::string formatted = params.prompt;
+    if (!params.no_chat) {
+        const char * tmpl = llama_model_chat_template(model, nullptr);
+        if (tmpl) {
+            llama_chat_message msg = {"user", params.prompt.c_str()};
+            int32_t len = llama_chat_apply_template(tmpl, &msg, 1, true, nullptr, 0);
+            if (len > 0) {
+                std::vector<char> buf(len + 1);
+                llama_chat_apply_template(tmpl, &msg, 1, true, buf.data(), buf.size());
+                formatted.assign(buf.data(), len);
+                fprintf(stderr, "ref: applied chat template (%d chars)\n", len);
+            }
+        }
+    }
+
+    std::vector<llama_token> prompt_tokens = common_tokenize(vocab, formatted, true, true);
+    const int32_t n_prompt = (int32_t)prompt_tokens.size();
+    const int32_t total_tokens = n_prompt + params.n_predict;
+
+    fprintf(stderr, "ref: n_vocab=%d, n_prompt=%d, n_predict=%d\n", n_vocab, n_prompt, params.n_predict);
+
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx   = std::max(params.n_ctx, total_tokens);
+    ctx_params.n_batch = std::max(params.n_ctx, total_tokens);
+
+    llama_context * ctx = llama_init_from_model(model, ctx_params);
+    if (!ctx) {
+        fprintf(stderr, "ref: failed to create context\n");
+        llama_model_free(model);
+        return 1;
+    }
+
+    const int32_t n_batch = llama_n_batch(ctx);
+
+    std::vector<int32_t> all_tokens(prompt_tokens.begin(), prompt_tokens.end());
+    all_tokens.reserve(total_tokens);
+
+    std::vector<float> all_logits;
+    all_logits.reserve((size_t)(total_tokens - 1) * n_vocab);
+
+    // sampler
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_top_k(params.top_k));
+    llama_sampler_chain_add(smpl, llama_sampler_init_top_p(params.top_p, 1));
+    llama_sampler_chain_add(smpl, llama_sampler_init_temp(params.temp));
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.seed));
+
+    // decode prompt
+    llama_batch batch = llama_batch_init(n_batch, 0, 1);
+
+    int32_t n_decoded = 0;
+    while (n_decoded < n_prompt) {
+        common_batch_clear(batch);
+        int32_t batch_end = std::min(n_prompt, n_decoded + n_batch);
+        for (int32_t i = n_decoded; i < batch_end; i++) {
+            common_batch_add(batch, prompt_tokens[i], i, {0}, i > 0);
+        }
+        if (llama_decode(ctx, batch) != 0) {
+            fprintf(stderr, "ref: decode failed at position %d\n", n_decoded);
+            llama_batch_free(batch); llama_sampler_free(smpl); llama_free(ctx); llama_model_free(model);
+            return 1;
+        }
+        for (int32_t i = n_decoded; i < batch_end; i++) {
+            if (i == 0) continue;
+            const float * logits = llama_get_logits_ith(ctx, i - n_decoded);
+            all_logits.insert(all_logits.end(), logits, logits + n_vocab);
+        }
+        n_decoded = batch_end;
+    }
+
+    fprintf(stderr, "ref: prompt decoded, generating...\n");
+
+    // generate
+    std::string generated_text;
+    for (int32_t i = 0; i < params.n_predict; i++) {
+        llama_token new_token = llama_sampler_sample(smpl, ctx, -1);
+        if (llama_vocab_is_eog(vocab, new_token)) {
+            fprintf(stderr, "\nref: EOS at step %d\n", i);
+            break;
+        }
+        all_tokens.push_back(new_token);
+
+        std::string piece = common_token_to_piece(vocab, new_token);
+        generated_text += piece;
+        fprintf(stdout, "%s", piece.c_str());
+        fflush(stdout);
+
+        common_batch_clear(batch);
+        common_batch_add(batch, new_token, n_prompt + i, {0}, true);
+        if (llama_decode(ctx, batch) != 0) {
+            fprintf(stderr, "\nref: decode failed at generation step %d\n", i);
+            break;
+        }
+        const float * logits = llama_get_logits_ith(ctx, 0);
+        all_logits.insert(all_logits.end(), logits, logits + n_vocab);
+    }
+    fprintf(stdout, "\n");
+
+    // write output (single-prompt v3 format)
+    trace_file out;
+    out.n_vocab   = n_vocab;
+    out.n_prompts = 1;
+    out.temp      = params.temp;
+    out.top_p     = params.top_p;
+    out.top_k     = params.top_k;
+    out.seed      = params.seed;
+
+    trace_entry & p = out.prompts.emplace_back();
+    p.path     = "inline";
+    p.n_tokens = (int32_t)all_tokens.size();
+    p.n_prompt = n_prompt;
+    p.tokens   = std::move(all_tokens);
+    p.logits   = std::move(all_logits);
+
+    if (!trace_write(params.output_path, out)) {
+        fprintf(stderr, "ref: failed to write '%s'\n", params.output_path.c_str());
+        llama_batch_free(batch); llama_sampler_free(smpl); llama_free(ctx); llama_model_free(model);
+        return 1;
+    }
+
+    fprintf(stderr, "ref: wrote %s (%d tokens)\n", params.output_path.c_str(), p.n_tokens);
+
+    // write generated text sidecar
+    std::string txt_path = params.output_path;
+    if (txt_path.size() > 4 && txt_path.substr(txt_path.size() - 4) == ".bin") {
+        txt_path.replace(txt_path.size() - 4, 4, ".txt");
+    } else {
+        txt_path += ".txt";
+    }
+    FILE * txt_fp = fopen(txt_path.c_str(), "w");
+    if (txt_fp) {
+        fprintf(txt_fp, "%s\n", generated_text.c_str());
+        fclose(txt_fp);
+        fprintf(stderr, "ref: wrote %s\n", txt_path.c_str());
+    }
+
+    llama_batch_free(batch);
+    llama_sampler_free(smpl);
+    llama_free(ctx);
+    llama_model_free(model);
+    return 0;
+}

--- a/kv-transfer/src/target.cpp
+++ b/kv-transfer/src/target.cpp
@@ -1,3 +1,155 @@
 #include "target.h"
+#include "trace_io.h"
+
+#include "llama.h"
+#include "common.h"
+
+#include <algorithm>
 #include <cstdio>
-int cmd_target(int, char **) { fprintf(stderr, "target: not yet implemented\n"); return 1; }
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+struct target_params {
+    std::string model_path;
+    std::string input_path;
+    std::string output_path = "target.bin";
+    int32_t     n_gpu_layers = 99;
+    int32_t     n_ctx        = 0;
+};
+
+static bool parse_args(int argc, char ** argv, target_params & params) {
+    for (int i = 1; i < argc; i++) {
+        const char * arg = argv[i];
+        if (strcmp(arg, "-m") == 0 && i + 1 < argc) {
+            params.model_path = argv[++i];
+        } else if (strcmp(arg, "-i") == 0 && i + 1 < argc) {
+            params.input_path = argv[++i];
+        } else if (strcmp(arg, "-o") == 0 && i + 1 < argc) {
+            params.output_path = argv[++i];
+        } else if (strcmp(arg, "-ngl") == 0 && i + 1 < argc) {
+            params.n_gpu_layers = atoi(argv[++i]);
+        } else if (strcmp(arg, "-c") == 0 && i + 1 < argc) {
+            params.n_ctx = atoi(argv[++i]);
+        } else {
+            fprintf(stderr, "target: unknown argument '%s'\n", arg);
+            return false;
+        }
+    }
+    if (params.model_path.empty() || params.input_path.empty()) {
+        fprintf(stderr, "Usage: kv-transfer target -m <model> -i <ref.bin> [options]\n"
+                        "  -o <path>    output file (default: target.bin)\n"
+                        "  -ngl <int>   GPU layers (default: 99)\n"
+                        "  -c <int>     context size (default: auto)\n");
+        return false;
+    }
+    return true;
+}
+
+int cmd_target(int argc, char ** argv) {
+    target_params params;
+    if (!parse_args(argc, argv, params)) return 1;
+
+    // read tokens from reference (skip logits)
+    trace_file ref;
+    if (!trace_read_tokens(params.input_path, ref)) {
+        fprintf(stderr, "target: failed to read '%s'\n", params.input_path.c_str());
+        return 1;
+    }
+
+    if (ref.n_prompts != 1) {
+        fprintf(stderr, "target: expected single-prompt file, got %d\n", ref.n_prompts);
+        return 1;
+    }
+
+    const auto & rp = ref.prompts[0];
+    const int32_t n_tokens = rp.n_tokens;
+
+    fprintf(stderr, "target: read %d tokens from '%s'\n", n_tokens, params.input_path.c_str());
+
+    ggml_backend_load_all();
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.n_gpu_layers = params.n_gpu_layers;
+
+    llama_model * model = llama_model_load_from_file(params.model_path.c_str(), model_params);
+    if (!model) {
+        fprintf(stderr, "target: failed to load model '%s'\n", params.model_path.c_str());
+        return 1;
+    }
+
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+
+    if (n_vocab != ref.n_vocab) {
+        fprintf(stderr, "target: vocab mismatch: model=%d, ref=%d\n", n_vocab, ref.n_vocab);
+        llama_model_free(model);
+        return 1;
+    }
+
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx   = params.n_ctx > 0 ? params.n_ctx : n_tokens;
+    ctx_params.n_batch = n_tokens;
+
+    llama_context * ctx = llama_init_from_model(model, ctx_params);
+    if (!ctx) {
+        fprintf(stderr, "target: failed to create context\n");
+        llama_model_free(model);
+        return 1;
+    }
+
+    const int32_t n_batch = llama_n_batch(ctx);
+
+    std::vector<float> all_logits;
+    all_logits.reserve((size_t)(n_tokens - 1) * n_vocab);
+
+    llama_batch batch = llama_batch_init(n_batch, 0, 1);
+
+    int32_t n_processed = 0;
+    while (n_processed < n_tokens) {
+        common_batch_clear(batch);
+        int32_t batch_end = std::min(n_tokens, n_processed + n_batch);
+        for (int32_t i = n_processed; i < batch_end; i++) {
+            common_batch_add(batch, rp.tokens[i], i, {0}, i > 0);
+        }
+        if (llama_decode(ctx, batch) != 0) {
+            fprintf(stderr, "target: decode failed at position %d\n", n_processed);
+            llama_batch_free(batch); llama_free(ctx); llama_model_free(model);
+            return 1;
+        }
+        for (int32_t i = n_processed; i < batch_end; i++) {
+            if (i == 0) continue;
+            const float * logits = llama_get_logits_ith(ctx, i - n_processed);
+            all_logits.insert(all_logits.end(), logits, logits + n_vocab);
+        }
+        n_processed = batch_end;
+        fprintf(stderr, "target: processed %d / %d tokens\r", n_processed, n_tokens);
+    }
+    fprintf(stderr, "\n");
+
+    // write output
+    trace_file out;
+    out.n_vocab   = n_vocab;
+    out.n_prompts = 1;
+
+    trace_entry & p = out.prompts.emplace_back();
+    p.path     = rp.path;
+    p.n_tokens = n_tokens;
+    p.n_prompt = rp.n_prompt;
+    p.tokens.assign(rp.tokens.begin(), rp.tokens.end());
+    p.logits   = std::move(all_logits);
+
+    if (!trace_write(params.output_path, out)) {
+        fprintf(stderr, "target: failed to write '%s'\n", params.output_path.c_str());
+        llama_batch_free(batch); llama_free(ctx); llama_model_free(model);
+        return 1;
+    }
+
+    fprintf(stderr, "target: wrote %s (%d tokens)\n", params.output_path.c_str(), n_tokens);
+
+    llama_batch_free(batch);
+    llama_free(ctx);
+    llama_model_free(model);
+    return 0;
+}


### PR DESCRIPTION
ref: loads a model, processes a prompt (with optional chat template), generates tokens via top-k/top-p sampling, and saves the full token sequence + logits to a v3 trace file. Also writes a .txt sidecar with the generated text for sanity checking.

target: reads tokens from a ref trace file (skipping logits), replays them through a different model, and saves that model's logits. This is the "just use the smaller model" baseline.

Both subcommands handle batched decoding for prompts longer than n_batch, collect per-position logits, and write single-prompt v3 files.