### PR TITLE
kv-transfer: implement compare and decay subcommands

### DIFF
--- a/kv-transfer/src/compare.cpp
+++ b/kv-transfer/src/compare.cpp
@@ -1,3 +1,108 @@
 #include "compare.h"
+#include "trace_io.h"
+#include "kl_utils.h"
+
+#include <atomic>
+#include <cmath>
 #include <cstdio>
-int cmd_compare(int, char **) { fprintf(stderr, "compare: not yet implemented\n"); return 1; }
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct compare_params {
+    std::string path_a;
+    std::string path_b;
+};
+
+static bool parse_args(int argc, char ** argv, compare_params & params) {
+    for (int i = 1; i < argc; i++) {
+        const char * arg = argv[i];
+        if (strcmp(arg, "-a") == 0 && i + 1 < argc) {
+            params.path_a = argv[++i];
+        } else if (strcmp(arg, "-b") == 0 && i + 1 < argc) {
+            params.path_b = argv[++i];
+        } else {
+            fprintf(stderr, "compare: unknown argument '%s'\n", arg);
+            return false;
+        }
+    }
+    if (params.path_a.empty() || params.path_b.empty()) {
+        fprintf(stderr, "Usage: kv-transfer compare -a <ref.bin> -b <other.bin>\n");
+        return false;
+    }
+    return true;
+}
+
+int cmd_compare(int argc, char ** argv) {
+    compare_params params;
+    if (!parse_args(argc, argv, params)) return 1;
+
+    fprintf(stderr, "compare: loading '%s'...\n", params.path_a.c_str());
+    trace_file fa;
+    if (!trace_read(params.path_a, fa)) return 1;
+
+    fprintf(stderr, "compare: loading '%s'...\n", params.path_b.c_str());
+    trace_file fb;
+    if (!trace_read(params.path_b, fb)) return 1;
+
+    if (fa.n_vocab != fb.n_vocab) {
+        fprintf(stderr, "compare: vocab mismatch (%d vs %d)\n", fa.n_vocab, fb.n_vocab);
+        return 1;
+    }
+    if (fa.n_prompts != 1 || fb.n_prompts != 1) {
+        fprintf(stderr, "compare: expected single-prompt files\n");
+        return 1;
+    }
+
+    const auto & pa = fa.prompts[0];
+    const auto & pb = fb.prompts[0];
+
+    if (pa.n_tokens != pb.n_tokens) {
+        fprintf(stderr, "compare: token count mismatch (%d vs %d)\n", pa.n_tokens, pb.n_tokens);
+        return 1;
+    }
+
+    const int32_t n_vocab  = fa.n_vocab;
+    const int32_t n_logits = pa.n_tokens - 1;
+    const int32_t n_threads = std::max(1, (int32_t)std::thread::hardware_concurrency());
+    const double ref_temp = (fa.temp > 0.0f) ? (double)fa.temp : 1.0;
+
+    std::vector<double> kl_per_pos(n_logits);
+    std::atomic<int32_t> top1_agree{0};
+    std::atomic<int32_t> counter{0};
+
+    auto worker = [&]() {
+        std::vector<double> log_p_ref, log_p_tgt;
+        int32_t local_agree = 0;
+        while (true) {
+            int32_t i = counter.fetch_add(1);
+            if (i >= n_logits) break;
+
+            const float * la = pa.logits.data() + (size_t)i * n_vocab;
+            const float * lb = pb.logits.data() + (size_t)i * n_vocab;
+
+            log_softmax_temp(la, n_vocab, ref_temp, log_p_ref);
+            log_softmax_temp(lb, n_vocab, ref_temp, log_p_tgt);
+
+            kl_per_pos[i] = kl_divergence(log_p_ref, log_p_tgt, n_vocab);
+
+            if (argmax(la, n_vocab) == argmax(lb, n_vocab)) local_agree++;
+        }
+        top1_agree.fetch_add(local_agree);
+    };
+
+    std::vector<std::thread> threads;
+    for (int32_t t = 0; t < n_threads; t++) threads.emplace_back(worker);
+    for (auto & t : threads) t.join();
+
+    double kl_sum = 0.0;
+    for (int32_t i = 0; i < n_logits; i++) kl_sum += kl_per_pos[i];
+    double kl_mean = kl_sum / n_logits;
+    double top1_pct = 100.0 * top1_agree.load() / n_logits;
+
+    printf("  KL divergence: %.6f\n", kl_mean);
+    printf("  Top-1 agree:   %.1f%%\n", top1_pct);
+
+    return 0;
+}

--- a/kv-transfer/src/decay.cpp
+++ b/kv-transfer/src/decay.cpp
@@ -1,3 +1,185 @@
 #include "decay.h"
+#include "trace_io.h"
+#include "kl_utils.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
 #include <cstdio>
-int cmd_decay(int, char **) { fprintf(stderr, "decay: not yet implemented\n"); return 1; }
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct decay_params {
+    std::string path_ref;
+    std::string path_target;
+    std::string path_handoff;
+    std::string csv_path;
+    int32_t     window = 64;
+    double      temp   = 0.6;
+};
+
+static bool parse_args(int argc, char ** argv, decay_params & params) {
+    for (int i = 1; i < argc; i++) {
+        const char * arg = argv[i];
+        if (strcmp(arg, "--ref") == 0 && i + 1 < argc) {
+            params.path_ref = argv[++i];
+        } else if (strcmp(arg, "--target") == 0 && i + 1 < argc) {
+            params.path_target = argv[++i];
+        } else if (strcmp(arg, "--handoff") == 0 && i + 1 < argc) {
+            params.path_handoff = argv[++i];
+        } else if (strcmp(arg, "--csv") == 0 && i + 1 < argc) {
+            params.csv_path = argv[++i];
+        } else if (strcmp(arg, "--window") == 0 && i + 1 < argc) {
+            params.window = atoi(argv[++i]);
+        } else if (strcmp(arg, "--temp") == 0 && i + 1 < argc) {
+            params.temp = atof(argv[++i]);
+        } else {
+            fprintf(stderr, "decay: unknown argument '%s'\n", arg);
+            return false;
+        }
+    }
+    if (params.path_ref.empty() || params.path_target.empty() || params.path_handoff.empty()) {
+        fprintf(stderr, "Usage: kv-transfer decay --ref <ref.bin> --target <target.bin> --handoff <handoff.bin> [options]\n"
+                        "  --csv <path>     output CSV\n"
+                        "  --window <int>   window size (default: 64)\n"
+                        "  --temp <float>   temperature (default: 0.6)\n");
+        return false;
+    }
+    return true;
+}
+
+struct window_stats {
+    int32_t start;
+    int32_t end;
+    double  kl_target;
+    double  top1_target;
+    double  kl_handoff;
+    double  top1_handoff;
+};
+
+static void compute_window_kl(
+    const trace_entry & ref, const trace_entry & other,
+    int32_t n_vocab, double temp, int32_t gen_start, int32_t win_start, int32_t win_end,
+    double & kl_out, double & top1_out, int32_t n_threads
+) {
+    const int32_t n = win_end - win_start;
+    std::vector<double> kl_per_pos(n);
+    std::atomic<int32_t> agree{0};
+    std::atomic<int32_t> counter{0};
+
+    auto worker = [&]() {
+        std::vector<double> lp_ref, lp_other;
+        int32_t local_agree = 0;
+        while (true) {
+            int32_t idx = counter.fetch_add(1);
+            if (idx >= n) break;
+            int32_t li = gen_start + win_start + idx;
+
+            const float * la = ref.logits.data() + (size_t)li * n_vocab;
+            const float * lb = other.logits.data() + (size_t)li * n_vocab;
+
+            log_softmax_temp(la, n_vocab, temp, lp_ref);
+            log_softmax_temp(lb, n_vocab, temp, lp_other);
+
+            kl_per_pos[idx] = kl_divergence(lp_ref, lp_other, n_vocab);
+            if (argmax(la, n_vocab) == argmax(lb, n_vocab)) local_agree++;
+        }
+        agree.fetch_add(local_agree);
+    };
+
+    std::vector<std::thread> threads;
+    for (int32_t t = 0; t < n_threads; t++) threads.emplace_back(worker);
+    for (auto & t : threads) t.join();
+
+    double sum = 0.0;
+    for (int32_t i = 0; i < n; i++) sum += kl_per_pos[i];
+    kl_out = sum / n;
+    top1_out = 100.0 * agree.load() / n;
+}
+
+int cmd_decay(int argc, char ** argv) {
+    decay_params params;
+    if (!parse_args(argc, argv, params)) return 1;
+
+    fprintf(stderr, "decay: loading ref...\n");
+    trace_file fa;
+    if (!trace_read(params.path_ref, fa)) return 1;
+
+    fprintf(stderr, "decay: loading target...\n");
+    trace_file fb;
+    if (!trace_read(params.path_target, fb)) return 1;
+
+    fprintf(stderr, "decay: loading handoff...\n");
+    trace_file fc;
+    if (!trace_read(params.path_handoff, fc)) return 1;
+
+    if (fa.n_prompts != 1 || fb.n_prompts != 1 || fc.n_prompts != 1) {
+        fprintf(stderr, "decay: expected single-prompt files\n");
+        return 1;
+    }
+
+    const auto & ref = fa.prompts[0];
+    const auto & tgt = fb.prompts[0];
+    const auto & hoff = fc.prompts[0];
+    const int32_t n_vocab = fa.n_vocab;
+    const int32_t n_logits = ref.n_tokens - 1;
+    const int32_t gen_start = ref.n_prompt - 1;
+    const int32_t gen_count = n_logits - gen_start;
+    const int32_t n_threads = std::max(1, (int32_t)std::thread::hardware_concurrency());
+
+    fprintf(stderr, "decay: n_vocab=%d, n_prompt=%d, gen=%d, window=%d, threads=%d\n",
+            n_vocab, ref.n_prompt, gen_count, params.window, n_threads);
+
+    std::vector<window_stats> windows;
+    int32_t pos = 0;
+    while (pos < gen_count) {
+        int32_t end = std::min(pos + params.window, gen_count);
+
+        window_stats ws;
+        ws.start = pos;
+        ws.end = end;
+
+        compute_window_kl(ref, tgt, n_vocab, params.temp, gen_start, pos, end,
+                          ws.kl_target, ws.top1_target, n_threads);
+        compute_window_kl(ref, hoff, n_vocab, params.temp, gen_start, pos, end,
+                          ws.kl_handoff, ws.top1_handoff, n_threads);
+
+        windows.push_back(ws);
+        pos = end;
+
+        fprintf(stderr, "  window %d-%d done\r", ws.start, ws.end);
+        fflush(stderr);
+    }
+    fprintf(stderr, "\n");
+
+    // print table
+    printf("%10s  %10s  %10s  %10s  %11s  %10s\n",
+           "Window", "KL(tgt)", "top1%(tgt)", "KL(hoff)", "top1%(hoff)", "KL ratio");
+    for (const auto & ws : windows) {
+        double ratio = ws.kl_target > 0 ? ws.kl_handoff / ws.kl_target : 0;
+        printf("%4d-%-4d   %10.4f  %9.1f%%  %10.4f  %10.1f%%  %10.3f\n",
+               ws.start, ws.end, ws.kl_target, ws.top1_target,
+               ws.kl_handoff, ws.top1_handoff, ratio);
+    }
+
+    // CSV
+    if (!params.csv_path.empty()) {
+        FILE * csv = fopen(params.csv_path.c_str(), "w");
+        if (!csv) {
+            fprintf(stderr, "decay: cannot open '%s'\n", params.csv_path.c_str());
+            return 1;
+        }
+        fprintf(csv, "window_start,window_end,kl_target,top1_target,kl_handoff,top1_handoff\n");
+        for (const auto & ws : windows) {
+            fprintf(csv, "%d,%d,%.6f,%.1f,%.6f,%.1f\n",
+                    ws.start, ws.end, ws.kl_target, ws.top1_target,
+                    ws.kl_handoff, ws.top1_handoff);
+        }
+        fclose(csv);
+        fprintf(stderr, "decay: wrote %s\n", params.csv_path.c_str());
+    }
+
+    return 0;
+}


### PR DESCRIPTION
compare: loads two trace files, computes per-position KL divergence and top-1 agreement using multithreaded workers. Reports mean KL and top-1% to stdout. Used for quick A/B comparison (e.g. ref vs target, ref vs handoff).

decay: loads all three trace files (ref, target, handoff), splits generation tokens into fixed-size windows, and computes windowed KL divergence + top-1 for both target and handoff vs ref. Reports a table with KL ratio per window, showing how the handoff benefit decays as the target model adds its own KV entries. Optionally writes results to CSV.

Both subcommands use temperature-scaled log-softmax from kl_utils.h and parallelize KL computation across hardware threads.

Tested: compare shows handoff KL ~0.53x of target KL on Q8→IQ2_XXS. Decay produces per-window breakdown.