### PR TITLE
kv-transfer: add test prompts and automated run harness

### DIFF
--- a/kv-transfer/prompts/01_python_bug.txt
+++ b/kv-transfer/prompts/01_python_bug.txt
@@ -1,0 +1,36 @@
+Find the bug in this Python program and explain how to fix it:
+
+```python
+def merge_sorted_lists(list1, list2):
+    result = []
+    i, j = 0, 0
+    while i < len(list1) and j < len(list2):
+        if list1[i] <= list2[j]:
+            result.append(list1[i])
+            i += 1
+        else:
+            result.append(list2[j])
+            j += 1
+    return result
+
+def find_median(nums):
+    sorted_nums = sorted(nums)
+    n = len(sorted_nums)
+    mid = n // 2
+    if n % 2 == 0:
+        return (sorted_nums[mid] + sorted_nums[mid - 1]) / 2
+    return sorted_nums[mid]
+
+def running_median(stream):
+    window = []
+    medians = []
+    for i, val in enumerate(stream):
+        window.append(val)
+        if len(window) > 5:
+            window.pop(0)
+        medians.append(find_median(window))
+    return medians
+
+data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5]
+print(running_median(data))
+```

--- a/kv-transfer/prompts/02_rust_explain.txt
+++ b/kv-transfer/prompts/02_rust_explain.txt
@@ -1,0 +1,61 @@
+Explain what this Rust program does, step by step:
+
+```rust
+use std::collections::HashMap;
+
+fn compress(input: &[u8]) -> Vec<(u8, u16)> {
+    let mut result = Vec::new();
+    if input.is_empty() {
+        return result;
+    }
+    let mut current = input[0];
+    let mut count: u16 = 1;
+    for &byte in &input[1..] {
+        if byte == current && count < u16::MAX {
+            count += 1;
+        } else {
+            result.push((current, count));
+            current = byte;
+            count = 1;
+        }
+    }
+    result.push((current, count));
+    result
+}
+
+fn decompress(data: &[(u8, u16)]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for &(byte, count) in data {
+        for _ in 0..count {
+            result.push(byte);
+        }
+    }
+    result
+}
+
+fn analyze(input: &[u8]) -> HashMap<u8, usize> {
+    let mut freq = HashMap::new();
+    for &b in input {
+        *freq.entry(b).or_insert(0) += 1;
+    }
+    freq
+}
+
+fn main() {
+    let data = b"AAABBBCCCCDDDDDEEEEE";
+    let compressed = compress(data);
+    let decompressed = decompress(&compressed);
+    let freq = analyze(data);
+
+    println!("Original size: {}", data.len());
+    println!("Compressed entries: {}", compressed.len());
+    println!("Ratio: {:.1}%", (compressed.len() * 3) as f64 / data.len() as f64 * 100.0);
+    println!("Roundtrip OK: {}", data.as_slice() == decompressed.as_slice());
+
+    let mut pairs: Vec<_> = freq.into_iter().collect();
+    pairs.sort_by(|a, b| b.1.cmp(&a.1));
+    for (byte, count) in pairs {
+        println!("  '{}': {}", byte as char, count);
+    }
+}
+```

--- a/kv-transfer/prompts/03_go_bug.txt
+++ b/kv-transfer/prompts/03_go_bug.txt
@@ -1,0 +1,61 @@
+Find all the bugs in this Go HTTP server and explain each one:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+type Counter struct {
+	counts map[string]int
+	mu     sync.Mutex
+}
+
+func NewCounter() *Counter {
+	return &Counter{}
+}
+
+func (c *Counter) Increment(key string) int {
+	c.mu.Lock()
+	c.counts[key]++
+	val := c.counts[key]
+	c.mu.Unlock()
+	return val
+}
+
+func (c *Counter) Get(key string) int {
+	return c.counts[key]
+}
+
+func (c *Counter) GetAll() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts
+}
+
+var counter = NewCounter()
+
+func handleIncrement(w http.ResponseWriter, r *http.Request) {
+	key := r.URL.Query().Get("key")
+	if key == "" {
+		http.Error(w, "missing key", 400)
+	}
+	val := counter.Increment(key)
+	fmt.Fprintf(w, "%d", val)
+}
+
+func handleGetAll(w http.ResponseWriter, r *http.Request) {
+	data := counter.GetAll()
+	json.NewEncoder(w).Encode(data)
+}
+
+func main() {
+	http.HandleFunc("/inc", handleIncrement)
+	http.HandleFunc("/all", handleGetAll)
+	http.ListenAndServe(":8080", nil)
+}
+```

--- a/kv-transfer/prompts/04_cpp_explain.txt
+++ b/kv-transfer/prompts/04_cpp_explain.txt
@@ -1,0 +1,83 @@
+Explain what this C++ program does and analyze its time complexity:
+
+```cpp
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <unordered_map>
+#include <algorithm>
+
+struct Node {
+    char ch;
+    int freq;
+    Node* left;
+    Node* right;
+    Node(char c, int f) : ch(c), freq(f), left(nullptr), right(nullptr) {}
+};
+
+struct Compare {
+    bool operator()(Node* a, Node* b) { return a->freq > b->freq; }
+};
+
+Node* buildTree(const std::string& text) {
+    std::unordered_map<char, int> freq;
+    for (char c : text) freq[c]++;
+
+    std::priority_queue<Node*, std::vector<Node*>, Compare> pq;
+    for (auto& [ch, f] : freq) {
+        pq.push(new Node(ch, f));
+    }
+
+    while (pq.size() > 1) {
+        Node* left = pq.top(); pq.pop();
+        Node* right = pq.top(); pq.pop();
+        Node* parent = new Node('\0', left->freq + right->freq);
+        parent->left = left;
+        parent->right = right;
+        pq.push(parent);
+    }
+    return pq.top();
+}
+
+void buildCodes(Node* node, const std::string& prefix,
+                std::unordered_map<char, std::string>& codes) {
+    if (!node) return;
+    if (!node->left && !node->right) {
+        codes[node->ch] = prefix.empty() ? "0" : prefix;
+        return;
+    }
+    buildCodes(node->left, prefix + "0", codes);
+    buildCodes(node->right, prefix + "1", codes);
+}
+
+std::string encode(const std::string& text,
+                   const std::unordered_map<char, std::string>& codes) {
+    std::string result;
+    for (char c : text) result += codes.at(c);
+    return result;
+}
+
+int main() {
+    std::string text = "this is an example of huffman encoding";
+
+    Node* root = buildTree(text);
+    std::unordered_map<char, std::string> codes;
+    buildCodes(root, "", codes);
+
+    std::vector<std::pair<char, std::string>> sorted_codes(codes.begin(), codes.end());
+    std::sort(sorted_codes.begin(), sorted_codes.end(),
+              [](auto& a, auto& b) { return a.second.size() < b.second.size(); });
+
+    for (auto& [ch, code] : sorted_codes) {
+        char display = (ch == ' ') ? '_' : ch;
+        std::cout << "  '" << display << "': " << code << std::endl;
+    }
+
+    std::string encoded = encode(text, codes);
+    std::cout << "Original:  " << text.size() * 8 << " bits" << std::endl;
+    std::cout << "Encoded:   " << encoded.size() << " bits" << std::endl;
+    std::cout << "Ratio:     " << (100.0 * encoded.size() / (text.size() * 8)) << "%" << std::endl;
+
+    return 0;
+}
+```

--- a/kv-transfer/prompts/05_js_bug.txt
+++ b/kv-transfer/prompts/05_js_bug.txt
@@ -1,0 +1,70 @@
+Find the bugs in this JavaScript event scheduler and explain each one:
+
+```javascript
+class EventScheduler {
+  constructor() {
+    this.events = [];
+    this.listeners = {};
+  }
+
+  schedule(name, time, callback) {
+    this.events.push({ name, time, callback });
+    this.events.sort((a, b) => a.time - b.time);
+  }
+
+  on(eventName, handler) {
+    if (!this.listeners[eventName]) {
+      this.listeners[eventName] = [];
+    }
+    this.listeners[eventName].push(handler);
+  }
+
+  off(eventName, handler) {
+    const list = this.listeners[eventName];
+    if (list) {
+      const idx = list.indexOf(handler);
+      if (idx >= 0) list.splice(idx, 1);
+    }
+  }
+
+  async run() {
+    const startTime = Date.now();
+    for (const event of this.events) {
+      const elapsed = Date.now() - startTime;
+      const wait = event.time - elapsed;
+      if (wait > 0) {
+        await new Promise(resolve => setTimeout(resolve, wait));
+      }
+      event.callback();
+
+      const handlers = this.listeners[event.name];
+      if (handlers) {
+        for (const handler of handlers) {
+          handler(event);
+        }
+      }
+    }
+  }
+
+  cancel(name) {
+    this.events = this.events.filter(e => e.name !== name);
+  }
+
+  reschedule(name, newTime) {
+    for (const event of this.events) {
+      if (event.name == name) {
+        event.time = newTime;
+      }
+    }
+  }
+}
+
+const scheduler = new EventScheduler();
+scheduler.schedule("backup", 1000, () => console.log("backing up..."));
+scheduler.schedule("cleanup", 2000, () => console.log("cleaning up..."));
+scheduler.schedule("report", 500, () => console.log("generating report..."));
+
+scheduler.on("backup", (e) => console.log(`${e.name} completed at ${e.time}ms`));
+
+scheduler.run().then(() => console.log("all events done"));
+```

--- a/kv-transfer/prompts/06_python_explain.txt
+++ b/kv-transfer/prompts/06_python_explain.txt
@@ -1,0 +1,75 @@
+Explain what this Python program does and describe the algorithm:
+
+```python
+from collections import defaultdict, deque
+
+def build_graph(edges):
+    graph = defaultdict(list)
+    in_degree = defaultdict(int)
+    nodes = set()
+    for u, v in edges:
+        graph[u].append(v)
+        in_degree[v] += 1
+        nodes.add(u)
+        nodes.add(v)
+    for node in nodes:
+        if node not in in_degree:
+            in_degree[node] = 0
+    return graph, in_degree, nodes
+
+def solve(edges):
+    graph, in_degree, nodes = build_graph(edges)
+
+    queue = deque()
+    for node in nodes:
+        if in_degree[node] == 0:
+            queue.append(node)
+
+    result = []
+    while queue:
+        node = queue.popleft()
+        result.append(node)
+        for neighbor in graph[node]:
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if len(result) != len(nodes):
+        return None
+    return result
+
+def find_all(edges):
+    graph, in_degree, nodes = build_graph(edges)
+    results = []
+
+    def backtrack(path, remaining_in_degree):
+        if len(path) == len(nodes):
+            results.append(list(path))
+            return
+        for node in sorted(nodes):
+            if node not in path and remaining_in_degree[node] == 0:
+                path.append(node)
+                new_degrees = dict(remaining_in_degree)
+                for neighbor in graph[node]:
+                    new_degrees[neighbor] -= 1
+                backtrack(path, new_degrees)
+                path.pop()
+
+    backtrack([], dict(in_degree))
+    return results
+
+edges = [
+    ("compile", "link"),
+    ("compile", "test"),
+    ("lint", "compile"),
+    ("deps", "compile"),
+    ("deps", "lint"),
+    ("link", "package"),
+    ("test", "package"),
+]
+
+print("One valid order:", solve(edges))
+print(f"All valid orders ({len(find_all(edges))} total):")
+for order in find_all(edges):
+    print("  ->".join(order))
+```

--- a/kv-transfer/prompts/07_c_bug.txt
+++ b/kv-transfer/prompts/07_c_bug.txt
@@ -1,0 +1,90 @@
+Find all memory-related bugs in this C program:
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    char* key;
+    char* value;
+} Entry;
+
+typedef struct {
+    Entry* entries;
+    int size;
+    int capacity;
+} Table;
+
+Table* table_create(int capacity) {
+    Table* t = malloc(sizeof(Table));
+    t->entries = malloc(sizeof(Entry) * capacity);
+    t->size = 0;
+    t->capacity = capacity;
+    return t;
+}
+
+void table_put(Table* t, const char* key, const char* value) {
+    for (int i = 0; i < t->size; i++) {
+        if (strcmp(t->entries[i].key, key) == 0) {
+            t->entries[i].value = strdup(value);
+            return;
+        }
+    }
+
+    if (t->size >= t->capacity) {
+        t->capacity *= 2;
+        t->entries = realloc(t->entries, sizeof(Entry) * t->capacity);
+    }
+
+    t->entries[t->size].key = strdup(key);
+    t->entries[t->size].value = strdup(value);
+    t->size++;
+}
+
+char* table_get(Table* t, const char* key) {
+    for (int i = 0; i < t->size; i++) {
+        if (strcmp(t->entries[i].key, key) == 0) {
+            return t->entries[i].value;
+        }
+    }
+    return NULL;
+}
+
+void table_delete(Table* t, const char* key) {
+    for (int i = 0; i < t->size; i++) {
+        if (strcmp(t->entries[i].key, key) == 0) {
+            t->entries[i] = t->entries[t->size - 1];
+            t->size--;
+            return;
+        }
+    }
+}
+
+void table_free(Table* t) {
+    for (int i = 0; i < t->size; i++) {
+        free(t->entries[i].key);
+        free(t->entries[i].value);
+    }
+    free(t->entries);
+    free(t);
+}
+
+int main() {
+    Table* t = table_create(4);
+
+    table_put(t, "name", "Alice");
+    table_put(t, "city", "Portland");
+    table_put(t, "lang", "C");
+    table_put(t, "name", "Bob");
+
+    printf("name: %s\n", table_get(t, "name"));
+    printf("city: %s\n", table_get(t, "city"));
+
+    table_delete(t, "city");
+    printf("after delete, city: %s\n", table_get(t, "city") ?: "(null)");
+
+    table_free(t);
+    return 0;
+}
+```

--- a/kv-transfer/prompts/08_java_explain.txt
+++ b/kv-transfer/prompts/08_java_explain.txt
@@ -1,0 +1,99 @@
+Explain what this Java program does and describe the data structure:
+
+```java
+import java.util.*;
+
+public class LRUCache<K, V> {
+    private final int capacity;
+    private final Map<K, Node<K, V>> map;
+    private final Node<K, V> head;
+    private final Node<K, V> tail;
+
+    static class Node<K, V> {
+        K key;
+        V value;
+        Node<K, V> prev, next;
+        Node(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    public LRUCache(int capacity) {
+        this.capacity = capacity;
+        this.map = new HashMap<>();
+        this.head = new Node<>(null, null);
+        this.tail = new Node<>(null, null);
+        head.next = tail;
+        tail.prev = head;
+    }
+
+    public V get(K key) {
+        Node<K, V> node = map.get(key);
+        if (node == null) return null;
+        remove(node);
+        addToFront(node);
+        return node.value;
+    }
+
+    public void put(K key, V value) {
+        Node<K, V> existing = map.get(key);
+        if (existing != null) {
+            existing.value = value;
+            remove(existing);
+            addToFront(existing);
+            return;
+        }
+        if (map.size() >= capacity) {
+            Node<K, V> lru = tail.prev;
+            remove(lru);
+            map.remove(lru.key);
+        }
+        Node<K, V> node = new Node<>(key, value);
+        map.put(key, node);
+        addToFront(node);
+    }
+
+    private void remove(Node<K, V> node) {
+        node.prev.next = node.next;
+        node.next.prev = node.prev;
+    }
+
+    private void addToFront(Node<K, V> node) {
+        node.next = head.next;
+        node.prev = head;
+        head.next.prev = node;
+        head.next = node;
+    }
+
+    public void printState() {
+        System.out.print("Cache [");
+        Node<K, V> curr = head.next;
+        boolean first = true;
+        while (curr != tail) {
+            if (!first) System.out.print(", ");
+            System.out.print(curr.key + "=" + curr.value);
+            curr = curr.next;
+            first = false;
+        }
+        System.out.println("]");
+    }
+
+    public static void main(String[] args) {
+        LRUCache<String, Integer> cache = new LRUCache<>(3);
+        cache.put("a", 1);
+        cache.put("b", 2);
+        cache.put("c", 3);
+        cache.printState();  // c=3, b=2, a=1
+
+        cache.get("a");
+        cache.printState();  // a=1, c=3, b=2
+
+        cache.put("d", 4);
+        cache.printState();  // d=4, a=1, c=3 (b evicted)
+
+        cache.put("b", 5);
+        cache.printState();  // b=5, d=4, a=1 (c evicted)
+    }
+}
+```

--- a/kv-transfer/prompts/09_python_large.txt
+++ b/kv-transfer/prompts/09_python_large.txt
@@ -1,0 +1,273 @@
+Review this Python codebase for bugs, performance issues, and design problems. Explain each issue you find and suggest fixes.
+
+```python
+import threading
+import time
+import sqlite3
+import hashlib
+import json
+import os
+from collections import defaultdict
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+@dataclass
+class CacheEntry:
+    key: str
+    value: Any
+    expires_at: float
+    size_bytes: int
+    access_count: int = 0
+    last_accessed: float = field(default_factory=time.time)
+
+class LRUEvictionPolicy:
+    def __init__(self):
+        self.access_order = []
+
+    def record_access(self, key: str):
+        if key in self.access_order:
+            self.access_order.remove(key)
+        self.access_order.append(key)
+
+    def get_eviction_candidate(self) -> Optional[str]:
+        if self.access_order:
+            return self.access_order[0]
+        return None
+
+    def remove(self, key: str):
+        if key in self.access_order:
+            self.access_order.remove(key)
+
+class TTLEvictionPolicy:
+    def __init__(self):
+        self.entries = {}
+
+    def record_access(self, key: str, expires_at: float):
+        self.entries[key] = expires_at
+
+    def get_expired_keys(self) -> List[str]:
+        now = time.time()
+        expired = []
+        for key, expires_at in self.entries.items():
+            if expires_at < now:
+                expired.append(key)
+        return expired
+
+    def remove(self, key: str):
+        if key in self.entries:
+            del self.entries[key]
+
+class CacheStore:
+    def __init__(self, max_size_bytes: int = 100 * 1024 * 1024,
+                 default_ttl: int = 3600,
+                 db_path: str = "cache.db"):
+        self.max_size_bytes = max_size_bytes
+        self.default_ttl = default_ttl
+        self.current_size = 0
+        self.entries: Dict[str, CacheEntry] = {}
+        self.lock = threading.Lock()
+        self.lru = LRUEvictionPolicy()
+        self.ttl = TTLEvictionPolicy()
+        self.stats = defaultdict(int)
+
+        self.db = sqlite3.connect(db_path)
+        self.db.execute("""
+            CREATE TABLE IF NOT EXISTS cache_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                operation TEXT,
+                key TEXT,
+                hit BOOLEAN
+            )
+        """)
+
+    def _compute_size(self, value: Any) -> int:
+        return len(json.dumps(value))
+
+    def _hash_key(self, key: str) -> str:
+        return hashlib.md5(key.encode()).hexdigest()
+
+    def get(self, key: str) -> Optional[Any]:
+        hashed = self._hash_key(key)
+        self.lock.acquire()
+
+        if hashed not in self.entries:
+            self.stats['misses'] += 1
+            self._log_operation('GET', key, False)
+            self.lock.release()
+            return None
+
+        entry = self.entries[hashed]
+
+        if entry.expires_at < time.time():
+            del self.entries[hashed]
+            self.current_size -= entry.size_bytes
+            self.lru.remove(hashed)
+            self.ttl.remove(hashed)
+            self.stats['expired'] += 1
+            self._log_operation('GET', key, False)
+            self.lock.release()
+            return None
+
+        entry.access_count += 1
+        entry.last_accessed = time.time()
+        self.lru.record_access(hashed)
+        self.stats['hits'] += 1
+        self._log_operation('GET', key, True)
+        self.lock.release()
+        return entry.value
+
+    def put(self, key: str, value: Any, ttl: Optional[int] = None) -> bool:
+        if ttl is None:
+            ttl = self.default_ttl
+
+        hashed = self._hash_key(key)
+        size = self._compute_size(value)
+
+        if size > self.max_size_bytes:
+            return False
+
+        self.lock.acquire()
+
+        if hashed in self.entries:
+            old = self.entries[hashed]
+            self.current_size -= old.size_bytes
+
+        while self.current_size + size > self.max_size_bytes:
+            candidate = self.lru.get_eviction_candidate()
+            if candidate is None:
+                break
+            self._evict(candidate)
+
+        entry = CacheEntry(
+            key=key,
+            value=value,
+            expires_at=time.time() + ttl,
+            size_bytes=size,
+        )
+        self.entries[hashed] = entry
+        self.current_size += size
+        self.lru.record_access(hashed)
+        self.ttl.record_access(hashed, entry.expires_at)
+        self.stats['puts'] += 1
+        self._log_operation('PUT', key, True)
+        self.lock.release()
+        return True
+
+    def delete(self, key: str) -> bool:
+        hashed = self._hash_key(key)
+        self.lock.acquire()
+        if hashed in self.entries:
+            self._evict(hashed)
+            self.lock.release()
+            return True
+        self.lock.release()
+        return False
+
+    def _evict(self, hashed_key: str):
+        if hashed_key in self.entries:
+            entry = self.entries[hashed_key]
+            self.current_size -= entry.size_bytes
+            del self.entries[hashed_key]
+            self.lru.remove(hashed_key)
+            self.ttl.remove(hashed_key)
+            self.stats['evictions'] += 1
+
+    def cleanup_expired(self):
+        self.lock.acquire()
+        expired = self.ttl.get_expired_keys()
+        for key in expired:
+            self._evict(key)
+        self.lock.release()
+        return len(expired)
+
+    def _log_operation(self, operation: str, key: str, hit: bool):
+        self.db.execute(
+            "INSERT INTO cache_log (timestamp, operation, key, hit) VALUES (?, ?, ?, ?)",
+            (datetime.now().isoformat(), operation, key, hit)
+        )
+        self.db.commit()
+
+    def get_stats(self) -> Dict[str, int]:
+        total = self.stats['hits'] + self.stats['misses']
+        hit_rate = self.stats['hits'] / total if total > 0 else 0
+        return {
+            **dict(self.stats),
+            'total_requests': total,
+            'hit_rate': hit_rate,
+            'current_entries': len(self.entries),
+            'current_size_bytes': self.current_size,
+        }
+
+class CacheWarmer:
+    def __init__(self, cache: CacheStore, warmup_keys: List[str]):
+        self.cache = cache
+        self.warmup_keys = warmup_keys
+
+    def warm(self, data_source: Dict[str, Any]):
+        for key in self.warmup_keys:
+            if key in data_source:
+                self.cache.put(key, data_source[key])
+
+class PeriodicCleaner:
+    def __init__(self, cache: CacheStore, interval: int = 60):
+        self.cache = cache
+        self.interval = interval
+        self.running = False
+        self.thread = None
+
+    def start(self):
+        self.running = True
+        self.thread = threading.Thread(target=self._run)
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        if self.thread:
+            self.thread.join()
+
+    def _run(self):
+        while self.running:
+            cleaned = self.cache.cleanup_expired()
+            if cleaned > 0:
+                print(f"Cleaned {cleaned} expired entries")
+            time.sleep(self.interval)
+
+def benchmark(cache: CacheStore, n_operations: int = 10000):
+    import random
+    import string
+
+    keys = [''.join(random.choices(string.ascii_lowercase, k=10)) for _ in range(100)]
+    values = [{'data': ''.join(random.choices(string.ascii_lowercase, k=100))} for _ in range(100)]
+
+    start = time.time()
+    for i in range(n_operations):
+        idx = i % len(keys)
+        if random.random() < 0.7:
+            cache.get(keys[idx])
+        else:
+            cache.put(keys[idx], values[idx], ttl=random.randint(10, 300))
+    elapsed = time.time() - start
+
+    stats = cache.get_stats()
+    print(f"Benchmark: {n_operations} ops in {elapsed:.2f}s ({n_operations/elapsed:.0f} ops/sec)")
+    print(f"Stats: {json.dumps(stats, indent=2)}")
+
+if __name__ == "__main__":
+    cache = CacheStore(max_size_bytes=10 * 1024 * 1024)
+    cleaner = PeriodicCleaner(cache, interval=30)
+    cleaner.start()
+
+    cache.put("user:1", {"name": "Alice", "email": "alice@example.com"})
+    cache.put("user:2", {"name": "Bob", "email": "bob@example.com"})
+    cache.put("config", {"theme": "dark", "lang": "en"}, ttl=7200)
+
+    print(cache.get("user:1"))
+    print(cache.get("nonexistent"))
+    print(cache.get_stats())
+
+    benchmark(cache, 1000)
+
+    cleaner.stop()
+```

--- a/kv-transfer/prompts/10_go_large.txt
+++ b/kv-transfer/prompts/10_go_large.txt
@@ -1,0 +1,261 @@
+Review this Go codebase for bugs, race conditions, and design issues. Explain each problem and how to fix it.
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type Job struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Payload   string    `json:"payload"`
+	Status    string    `json:"status"`
+	Result    string    `json:"result,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	StartedAt time.Time `json:"started_at,omitempty"`
+	DoneAt    time.Time `json:"done_at,omitempty"`
+	Retries   int       `json:"retries"`
+	MaxRetry  int       `json:"max_retry"`
+}
+
+type WorkerPool struct {
+	workers    int
+	jobQueue   chan *Job
+	results    map[string]*Job
+	mu         sync.Mutex
+	wg         sync.WaitGroup
+	ctx        context.Context
+	cancel     context.CancelFunc
+	handlers   map[string]func(string) (string, error)
+	middleware []func(*Job) error
+}
+
+func NewWorkerPool(workers, queueSize int) *WorkerPool {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &WorkerPool{
+		workers:  workers,
+		jobQueue: make(chan *Job, queueSize),
+		results:  make(map[string]*Job),
+		ctx:      ctx,
+		cancel:   cancel,
+		handlers: make(map[string]func(string) (string, error)),
+	}
+}
+
+func (wp *WorkerPool) RegisterHandler(name string, handler func(string) (string, error)) {
+	wp.handlers[name] = handler
+}
+
+func (wp *WorkerPool) Use(mw func(*Job) error) {
+	wp.middleware = append(wp.middleware, mw)
+}
+
+func (wp *WorkerPool) Submit(job *Job) error {
+	job.Status = "queued"
+	job.CreatedAt = time.Now()
+	if job.MaxRetry == 0 {
+		job.MaxRetry = 3
+	}
+
+	wp.mu.Lock()
+	wp.results[job.ID] = job
+	wp.mu.Unlock()
+
+	wp.jobQueue <- job
+	return nil
+}
+
+func (wp *WorkerPool) GetJob(id string) *Job {
+	wp.mu.Lock()
+	job := wp.results[id]
+	wp.mu.Unlock()
+	return job
+}
+
+func (wp *WorkerPool) Start() {
+	for i := 0; i < wp.workers; i++ {
+		wp.wg.Add(1)
+		go wp.worker(i)
+	}
+}
+
+func (wp *WorkerPool) Stop() {
+	wp.cancel()
+	close(wp.jobQueue)
+	wp.wg.Wait()
+}
+
+func (wp *WorkerPool) worker(id int) {
+	defer wp.wg.Done()
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case job := <-wp.jobQueue:
+			wp.processJob(id, job)
+		}
+	}
+}
+
+func (wp *WorkerPool) processJob(workerID int, job *Job) {
+	log.Printf("[worker %d] processing job %s (%s)", workerID, job.ID, job.Name)
+
+	for _, mw := range wp.middleware {
+		if err := mw(job); err != nil {
+			job.Status = "failed"
+			job.Result = fmt.Sprintf("middleware error: %v", err)
+			return
+		}
+	}
+
+	handler, ok := wp.handlers[job.Name]
+	if !ok {
+		job.Status = "failed"
+		job.Result = fmt.Sprintf("no handler for job type: %s", job.Name)
+		return
+	}
+
+	job.Status = "running"
+	job.StartedAt = time.Now()
+
+	result, err := handler(job.Payload)
+	if err != nil {
+		job.Retries++
+		if job.Retries < job.MaxRetry {
+			log.Printf("[worker %d] job %s failed, retrying (%d/%d)",
+				workerID, job.ID, job.Retries, job.MaxRetry)
+			time.Sleep(time.Duration(job.Retries) * time.Second)
+			wp.jobQueue <- job
+			return
+		}
+		job.Status = "failed"
+		job.Result = err.Error()
+	} else {
+		job.Status = "completed"
+		job.Result = result
+	}
+	job.DoneAt = time.Now()
+}
+
+type RateLimiter struct {
+	tokens     float64
+	maxTokens  float64
+	refillRate float64
+	lastRefill time.Time
+	mu         sync.Mutex
+}
+
+func NewRateLimiter(maxTokens, refillRate float64) *RateLimiter {
+	return &RateLimiter{
+		tokens:     maxTokens,
+		maxTokens:  maxTokens,
+		refillRate: refillRate,
+		lastRefill: time.Now(),
+	}
+}
+
+func (rl *RateLimiter) Allow() bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(rl.lastRefill).Seconds()
+	rl.tokens += elapsed * rl.refillRate
+	if rl.tokens > rl.maxTokens {
+		rl.tokens = rl.maxTokens
+	}
+	rl.lastRefill = now
+
+	if rl.tokens >= 1 {
+		rl.tokens--
+		return true
+	}
+	return false
+}
+
+func loggingMiddleware(job *Job) error {
+	log.Printf("Processing job: %s (type: %s)", job.ID, job.Name)
+	return nil
+}
+
+func rateLimitMiddleware(limiter *RateLimiter) func(*Job) error {
+	return func(job *Job) error {
+		if !limiter.Allow() {
+			return fmt.Errorf("rate limit exceeded")
+		}
+		return nil
+	}
+}
+
+func main() {
+	pool := NewWorkerPool(4, 100)
+
+	pool.RegisterHandler("compute", func(payload string) (string, error) {
+		time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
+		if rand.Float64() < 0.3 {
+			return "", fmt.Errorf("random failure")
+		}
+		return fmt.Sprintf("computed: %s", payload), nil
+	})
+
+	pool.RegisterHandler("notify", func(payload string) (string, error) {
+		time.Sleep(500 * time.Millisecond)
+		return fmt.Sprintf("notified: %s", payload), nil
+	})
+
+	limiter := NewRateLimiter(10, 2)
+	pool.Use(loggingMiddleware)
+	pool.Use(rateLimitMiddleware(limiter))
+	pool.Start()
+
+	http.HandleFunc("/submit", func(w http.ResponseWriter, r *http.Request) {
+		var job Job
+		if err := json.NewDecoder(r.Body).Decode(&job); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		if err := pool.Submit(&job); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "queued", "id": job.ID})
+	})
+
+	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+		job := pool.GetJob(id)
+		if job == nil {
+			http.Error(w, "not found", 404)
+			return
+		}
+		json.NewEncoder(w).Encode(job)
+	})
+
+	http.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+		pool.mu.Lock()
+		stats := map[string]interface{}{
+			"total_jobs": len(pool.results),
+			"queue_size": len(pool.jobQueue),
+		}
+		counts := map[string]int{}
+		for _, job := range pool.results {
+			counts[job.Status]++
+		}
+		stats["by_status"] = counts
+		pool.mu.Unlock()
+		json.NewEncoder(w).Encode(stats)
+	})
+
+	log.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+```

--- a/kv-transfer/prompts/11_typescript_large.txt
+++ b/kv-transfer/prompts/11_typescript_large.txt
@@ -1,0 +1,271 @@
+Review this TypeScript codebase for bugs, type safety issues, and architectural problems. Explain each issue and suggest improvements.
+
+```typescript
+interface EventMap {
+  [event: string]: (...args: any[]) => void;
+}
+
+class TypedEventEmitter<T extends EventMap> {
+  private listeners: Map<keyof T, Set<Function>> = new Map();
+  private onceListeners: Map<keyof T, Set<Function>> = new Map();
+
+  on<K extends keyof T>(event: K, listener: T[K]): () => void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener);
+    return () => this.off(event, listener);
+  }
+
+  once<K extends keyof T>(event: K, listener: T[K]): void {
+    if (!this.onceListeners.has(event)) {
+      this.onceListeners.set(event, new Set());
+    }
+    this.onceListeners.get(event)!.add(listener);
+  }
+
+  off<K extends keyof T>(event: K, listener: T[K]): void {
+    this.listeners.get(event)?.delete(listener);
+    this.onceListeners.get(event)?.delete(listener);
+  }
+
+  emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): void {
+    this.listeners.get(event)?.forEach(fn => fn(...args));
+    const onceSet = this.onceListeners.get(event);
+    if (onceSet) {
+      onceSet.forEach(fn => fn(...args));
+      onceSet.clear();
+    }
+  }
+}
+
+type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+interface Task<T = any> {
+  id: string;
+  name: string;
+  execute: () => Promise<T>;
+  dependencies: string[];
+  timeout: number;
+  retries: number;
+  status: TaskStatus;
+  result?: T;
+  error?: Error;
+  startTime?: number;
+  endTime?: number;
+}
+
+interface PipelineEvents extends EventMap {
+  'task:start': (task: Task) => void;
+  'task:complete': (task: Task, result: any) => void;
+  'task:fail': (task: Task, error: Error) => void;
+  'task:retry': (task: Task, attempt: number) => void;
+  'pipeline:start': () => void;
+  'pipeline:complete': (results: Map<string, any>) => void;
+  'pipeline:fail': (error: Error) => void;
+}
+
+class Pipeline extends TypedEventEmitter<PipelineEvents> {
+  private tasks: Map<string, Task> = new Map();
+  private results: Map<string, any> = new Map();
+  private running: boolean = false;
+  private concurrency: number;
+
+  constructor(concurrency: number = 4) {
+    super();
+    this.concurrency = concurrency;
+  }
+
+  addTask<T>(config: {
+    id: string;
+    name: string;
+    execute: () => Promise<T>;
+    dependencies?: string[];
+    timeout?: number;
+    retries?: number;
+  }): this {
+    const task: Task<T> = {
+      ...config,
+      dependencies: config.dependencies || [],
+      timeout: config.timeout || 30000,
+      retries: config.retries || 0,
+      status: 'pending',
+    };
+    this.tasks.set(task.id, task);
+    return this;
+  }
+
+  private getReadyTasks(): Task[] {
+    const ready: Task[] = [];
+    for (const [id, task] of this.tasks) {
+      if (task.status !== 'pending') continue;
+      const depsComplete = task.dependencies.every(
+        dep => this.tasks.get(dep)?.status === 'completed'
+      );
+      if (depsComplete) ready.push(task);
+    }
+    return ready;
+  }
+
+  private async executeTask(task: Task): Promise<void> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= task.retries; attempt++) {
+      if (attempt > 0) {
+        this.emit('task:retry', task, attempt);
+        await new Promise(r => setTimeout(r, Math.pow(2, attempt) * 1000));
+      }
+
+      task.status = 'running';
+      task.startTime = Date.now();
+      this.emit('task:start', task);
+
+      try {
+        const result = await Promise.race([
+          task.execute(),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error(`Task ${task.id} timed out`)), task.timeout)
+          ),
+        ]);
+
+        task.status = 'completed';
+        task.result = result;
+        task.endTime = Date.now();
+        this.results.set(task.id, result);
+        this.emit('task:complete', task, result);
+        return;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+      }
+    }
+
+    task.status = 'failed';
+    task.error = lastError;
+    task.endTime = Date.now();
+    this.emit('task:fail', task, lastError!);
+  }
+
+  async run(): Promise<Map<string, any>> {
+    if (this.running) throw new Error('Pipeline already running');
+    this.running = true;
+    this.emit('pipeline:start');
+
+    try {
+      while (true) {
+        const ready = this.getReadyTasks();
+        if (ready.length === 0) {
+          const pending = [...this.tasks.values()].filter(t => t.status === 'pending');
+          const running = [...this.tasks.values()].filter(t => t.status === 'running');
+          if (pending.length === 0 && running.length === 0) break;
+          if (pending.length > 0 && running.length === 0) {
+            throw new Error('Deadlock: pending tasks with unresolvable dependencies');
+          }
+          await new Promise(r => setTimeout(r, 100));
+          continue;
+        }
+
+        const batch = ready.slice(0, this.concurrency);
+        await Promise.all(batch.map(task => this.executeTask(task)));
+      }
+
+      const failed = [...this.tasks.values()].filter(t => t.status === 'failed');
+      if (failed.length > 0) {
+        throw new Error(`${failed.length} tasks failed: ${failed.map(t => t.id).join(', ')}`);
+      }
+
+      this.emit('pipeline:complete', this.results);
+      return this.results;
+    } catch (err) {
+      this.emit('pipeline:fail', err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  cancel(): void {
+    for (const task of this.tasks.values()) {
+      if (task.status === 'pending' || task.status === 'running') {
+        task.status = 'cancelled';
+      }
+    }
+  }
+
+  getStatus(): Record<string, { status: TaskStatus; duration?: number }> {
+    const status: Record<string, { status: TaskStatus; duration?: number }> = {};
+    for (const [id, task] of this.tasks) {
+      status[id] = {
+        status: task.status,
+        duration: task.startTime && task.endTime
+          ? task.endTime - task.startTime
+          : undefined,
+      };
+    }
+    return status;
+  }
+}
+
+// Usage example
+async function main() {
+  const pipeline = new Pipeline(2);
+
+  pipeline.on('task:start', task => console.log(`Starting: ${task.name}`));
+  pipeline.on('task:complete', (task, result) =>
+    console.log(`Completed: ${task.name} (${task.endTime! - task.startTime!}ms)`)
+  );
+  pipeline.on('task:fail', (task, error) =>
+    console.log(`Failed: ${task.name}: ${error.message}`)
+  );
+
+  pipeline
+    .addTask({
+      id: 'fetch-users',
+      name: 'Fetch Users',
+      execute: async () => {
+        await new Promise(r => setTimeout(r, 1000));
+        return [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }];
+      },
+    })
+    .addTask({
+      id: 'fetch-orders',
+      name: 'Fetch Orders',
+      execute: async () => {
+        await new Promise(r => setTimeout(r, 1500));
+        return [{ userId: 1, amount: 100 }, { userId: 2, amount: 200 }];
+      },
+    })
+    .addTask({
+      id: 'merge-data',
+      name: 'Merge Data',
+      dependencies: ['fetch-users', 'fetch-orders'],
+      execute: async () => {
+        const users = pipeline['results'].get('fetch-users');
+        const orders = pipeline['results'].get('fetch-orders');
+        return users.map((u: any) => ({
+          ...u,
+          orders: orders.filter((o: any) => o.userId === u.id),
+        }));
+      },
+      timeout: 5000,
+    })
+    .addTask({
+      id: 'generate-report',
+      name: 'Generate Report',
+      dependencies: ['merge-data'],
+      execute: async () => {
+        const merged = pipeline['results'].get('merge-data');
+        return `Report: ${merged.length} users processed`;
+      },
+      retries: 2,
+    });
+
+  try {
+    const results = await pipeline.run();
+    console.log('Pipeline complete:', pipeline.getStatus());
+  } catch (err) {
+    console.error('Pipeline failed:', err);
+  }
+}
+
+main();
+```

--- a/kv-transfer/prompts/12_rust_large.txt
+++ b/kv-transfer/prompts/12_rust_large.txt
@@ -1,0 +1,249 @@
+Review this Rust codebase for soundness issues, performance problems, and API design concerns. Explain each issue you find.
+
+```rust
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+struct Metric {
+    name: String,
+    values: Vec<f64>,
+    timestamps: Vec<Instant>,
+}
+
+impl Metric {
+    fn new(name: &str) -> Self {
+        Metric {
+            name: name.to_string(),
+            values: Vec::new(),
+            timestamps: Vec::new(),
+        }
+    }
+
+    fn record(&mut self, value: f64) {
+        self.values.push(value);
+        self.timestamps.push(Instant::now());
+    }
+
+    fn mean(&self) -> f64 {
+        if self.values.is_empty() {
+            return 0.0;
+        }
+        self.values.iter().sum::<f64>() / self.values.len() as f64
+    }
+
+    fn percentile(&self, p: f64) -> f64 {
+        if self.values.is_empty() {
+            return 0.0;
+        }
+        let mut sorted = self.values.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let idx = ((p / 100.0) * sorted.len() as f64) as usize;
+        sorted[idx.min(sorted.len() - 1)]
+    }
+
+    fn rate(&self, window: Duration) -> f64 {
+        let now = Instant::now();
+        let count = self.timestamps.iter()
+            .filter(|t| now.duration_since(**t) < window)
+            .count();
+        count as f64 / window.as_secs_f64()
+    }
+
+    fn trim_older_than(&mut self, window: Duration) {
+        let now = Instant::now();
+        let cutoff = self.timestamps.iter()
+            .position(|t| now.duration_since(*t) < window);
+
+        if let Some(pos) = cutoff {
+            self.values.drain(..pos);
+            self.timestamps.drain(..pos);
+        }
+    }
+}
+
+struct MetricsRegistry {
+    metrics: RwLock<HashMap<String, Arc<Mutex<Metric>>>>,
+}
+
+impl MetricsRegistry {
+    fn new() -> Self {
+        MetricsRegistry {
+            metrics: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn get_or_create(&self, name: &str) -> Arc<Mutex<Metric>> {
+        {
+            let read = self.metrics.read().unwrap();
+            if let Some(metric) = read.get(name) {
+                return metric.clone();
+            }
+        }
+
+        let mut write = self.metrics.write().unwrap();
+        write.entry(name.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(Metric::new(name))))
+            .clone()
+    }
+
+    fn record(&self, name: &str, value: f64) {
+        let metric = self.get_or_create(name);
+        metric.lock().unwrap().record(value);
+    }
+
+    fn snapshot(&self) -> HashMap<String, MetricSnapshot> {
+        let read = self.metrics.read().unwrap();
+        let mut result = HashMap::new();
+        for (name, metric) in read.iter() {
+            let m = metric.lock().unwrap();
+            result.insert(name.clone(), MetricSnapshot {
+                name: name.clone(),
+                count: m.values.len(),
+                mean: m.mean(),
+                p50: m.percentile(50.0),
+                p95: m.percentile(95.0),
+                p99: m.percentile(99.0),
+                rate_1m: m.rate(Duration::from_secs(60)),
+            });
+        }
+        result
+    }
+}
+
+#[derive(Debug)]
+struct MetricSnapshot {
+    name: String,
+    count: usize,
+    mean: f64,
+    p50: f64,
+    p95: f64,
+    p99: f64,
+    rate_1m: f64,
+}
+
+struct Timer {
+    registry: Arc<MetricsRegistry>,
+    name: String,
+    start: Instant,
+}
+
+impl Timer {
+    fn new(registry: Arc<MetricsRegistry>, name: &str) -> Self {
+        Timer {
+            registry,
+            name: name.to_string(),
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for Timer {
+    fn drop(&mut self) {
+        let elapsed = self.start.elapsed().as_secs_f64() * 1000.0;
+        self.registry.record(&self.name, elapsed);
+    }
+}
+
+struct HistogramBucket {
+    le: f64,
+    count: u64,
+}
+
+struct Histogram {
+    buckets: Vec<HistogramBucket>,
+    sum: f64,
+    count: u64,
+}
+
+impl Histogram {
+    fn new(boundaries: &[f64]) -> Self {
+        let mut buckets: Vec<HistogramBucket> = boundaries.iter()
+            .map(|&le| HistogramBucket { le, count: 0 })
+            .collect();
+        buckets.push(HistogramBucket { le: f64::INFINITY, count: 0 });
+        Histogram { buckets, sum: 0.0, count: 0 }
+    }
+
+    fn observe(&mut self, value: f64) {
+        self.sum += value;
+        self.count += 1;
+        for bucket in &mut self.buckets {
+            if value <= bucket.le {
+                bucket.count += 1;
+            }
+        }
+    }
+
+    fn quantile(&self, q: f64) -> f64 {
+        let target = q * self.count as f64;
+        let mut prev_count = 0u64;
+        let mut prev_bound = 0.0f64;
+
+        for bucket in &self.buckets {
+            if bucket.count as f64 >= target {
+                if bucket.count == prev_count {
+                    return bucket.le;
+                }
+                let fraction = (target - prev_count as f64) /
+                    (bucket.count - prev_count) as f64;
+                return prev_bound + fraction * (bucket.le - prev_bound);
+            }
+            prev_count = bucket.count;
+            prev_bound = bucket.le;
+        }
+        self.buckets.last().map(|b| b.le).unwrap_or(0.0)
+    }
+}
+
+fn simulate_workload(registry: Arc<MetricsRegistry>) {
+    let mut rng_state: u64 = 42;
+
+    for i in 0..1000 {
+        rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let latency = (rng_state % 100) as f64 + 1.0;
+
+        {
+            let _timer = Timer::new(registry.clone(), "request_duration_ms");
+            thread::sleep(Duration::from_micros(latency as u64 * 10));
+        }
+
+        registry.record("request_size_bytes", (rng_state % 10000) as f64);
+        registry.record("response_size_bytes", (rng_state % 50000) as f64);
+
+        if i % 100 == 0 {
+            let snap = registry.snapshot();
+            for (name, s) in &snap {
+                println!("{}: count={} mean={:.2} p95={:.2} rate={:.1}/s",
+                    name, s.count, s.mean, s.p95, s.rate_1m);
+            }
+            println!("---");
+        }
+    }
+}
+
+fn main() {
+    let registry = Arc::new(MetricsRegistry::new());
+
+    let handles: Vec<_> = (0..4).map(|_| {
+        let reg = registry.clone();
+        thread::spawn(move || simulate_workload(reg))
+    }).collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    println!("\nFinal metrics:");
+    let snap = registry.snapshot();
+    let mut names: Vec<_> = snap.keys().collect();
+    names.sort();
+    for name in names {
+        let s = &snap[name];
+        println!("  {}: count={} mean={:.2} p50={:.2} p95={:.2} p99={:.2}",
+            name, s.count, s.mean, s.p50, s.p95, s.p99);
+    }
+}
+```

--- a/kv-transfer/run-qwen3.5-2b.sh
+++ b/kv-transfer/run-qwen3.5-2b.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Qwen3.5-2B: Q8_K_XL reference vs all lower quants
+
+REF_MODEL="$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-Q8_K_XL.gguf"
+REF_TAG="qwen3.5-2b-ud-q8_k_xl"
+
+TARGETS=(
+    "ud-iq2_xxs:$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-IQ2_XXS.gguf"
+    "ud-q2_k_xl:$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-Q2_K_XL.gguf"
+    "ud-q3_k_xl:$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-Q3_K_XL.gguf"
+    "ud-q4_k_xl:$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-Q4_K_XL.gguf"
+    "ud-q5_k_xl:$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-Q5_K_XL.gguf"
+    "ud-q6_k_xl:$HOME/projects/llms/qwen-3.5-2b/Qwen3.5-2B-UD-Q6_K_XL.gguf"
+)
+
+N_PREDICT=512
+TEMP=0.6
+
+source "$(dirname "$0")/run.sh"

--- a/kv-transfer/run-qwen3.5-35b-a3b.sh
+++ b/kv-transfer/run-qwen3.5-35b-a3b.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Qwen3.5-35B-A3B (MoE): Q8_K_XL reference vs lower quants
+
+REF_MODEL="$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-Q8_K_XL.gguf"
+REF_TAG="qwen3.5-35b-a3b-ud-q8_k_xl"
+
+TARGETS=(
+    "ud-iq2_xxs:$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-IQ2_XXS.gguf"
+    "ud-q2_k_xl:$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-Q2_K_XL.gguf"
+    "ud-q3_k_xl:$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-Q3_K_XL.gguf"
+    "ud-q4_k_xl:$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf"
+    "ud-q5_k_xl:$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-Q5_K_XL.gguf"
+    "ud-q6_k_xl:$HOME/projects/llms/qwen-3.5-35b-a3b/Qwen3.5-35B-A3B-UD-Q6_K_XL.gguf"
+)
+
+N_PREDICT=512
+TEMP=0.6
+
+source "$(dirname "$0")/run.sh"

--- a/kv-transfer/run.sh
+++ b/kv-transfer/run.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+set -euo pipefail
+
+# ==============================================================================
+# kv-transfer experiment runner
+#
+# This script expects the following variables to be set by the caller:
+#   REF_MODEL   — path to reference model GGUF
+#   REF_TAG     — short tag for results directory
+#   TARGETS     — array of "tag:path" pairs for target models
+#   N_PREDICT   — tokens to generate (default: 512)
+#   TEMP        — sampling temperature (default: 0.6)
+#   NGL         — GPU layers (default: 99)
+#
+# Usage: source config, then call this script. Or use a wrapper like:
+#   ./run-qwen3.5-2b.sh
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BINARY="${SCRIPT_DIR}/build/kv-transfer"
+PROMPTS="${SCRIPT_DIR}/prompts"
+RESULTS="${SCRIPT_DIR}/results"
+
+# defaults
+N_PREDICT="${N_PREDICT:-512}"
+TEMP="${TEMP:-0.6}"
+NGL="${NGL:-99}"
+
+# --- Validate config ---------------------------------------------------------
+
+if [ -z "${REF_MODEL:-}" ] || [ -z "${REF_TAG:-}" ] || [ ${#TARGETS[@]} -eq 0 ]; then
+    echo "ERROR: REF_MODEL, REF_TAG, and TARGETS must be set."
+    echo "Use a wrapper script like run-qwen3.5-2b.sh"
+    exit 1
+fi
+
+if [ ! -x "$BINARY" ]; then
+    echo "ERROR: kv-transfer not built. Run: cmake -B build && cmake --build build"
+    exit 1
+fi
+
+REF_DIR="${RESULTS}/${REF_TAG}"
+mkdir -p "$REF_DIR"
+
+# --- Helper: read token counts from .bin file --------------------------------
+
+read_token_counts() {
+    python3 -c "
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    f.read(8)  # magic
+    version = struct.unpack('I', f.read(4))[0]
+    f.read(4)  # n_vocab
+    f.read(4)  # n_prompts
+    f.read(4)  # unused
+    f.read(16) # temp, top_p, top_k, seed
+    f.read(28) # reserved
+    path_len = struct.unpack('i', f.read(4))[0]
+    f.read(path_len)
+    n_tokens = struct.unpack('i', f.read(4))[0]
+    n_prompt = struct.unpack('i', f.read(4))[0]
+    print(n_tokens, n_prompt)
+" "$1"
+}
+
+# Get total size in bytes for a model (handles split shards).
+model_size_bytes() {
+    python3 -c "
+import sys, os, glob, re
+path = sys.argv[1]
+m = re.match(r'(.+)-(\d+)-of-(\d+)(\.gguf)$', path)
+if m:
+    prefix, _, n_shards, ext = m.groups()
+    pattern = prefix + '-*-of-' + n_shards + ext
+    total = sum(os.path.getsize(f) for f in sorted(glob.glob(pattern)))
+else:
+    total = os.path.getsize(path)
+print(total)
+" "$1"
+}
+
+# --- Run ref for each prompt -------------------------------------------------
+
+echo "=== Reference: ${REF_TAG} ==="
+for prompt_file in "$PROMPTS"/*.txt; do
+    name=$(basename "$prompt_file" .txt)
+    ref_bin="${REF_DIR}/${name}-ref.bin"
+
+    if [ -f "$ref_bin" ]; then
+        echo "  [ref] $name — skip (exists)"
+        continue
+    fi
+
+    echo -n "  [ref] $name — running... "
+    prompt=$(cat "$prompt_file")
+    "$BINARY" ref \
+        -m "$REF_MODEL" \
+        -p "$prompt" \
+        -n "$N_PREDICT" --temp "$TEMP" -ngl "$NGL" \
+        -o "$ref_bin" > /dev/null 2>&1
+    echo "done"
+done
+echo ""
+
+# --- Run target + handoff for each target model ------------------------------
+
+for tgt_entry in "${TARGETS[@]}"; do
+    tgt_tag="${tgt_entry%%:*}"
+    tgt_model="${tgt_entry#*:}"
+    tgt_dir="${REF_DIR}/${tgt_tag}"
+    mkdir -p "$tgt_dir"
+
+    echo "=== Target: ${tgt_tag} ==="
+
+    for prompt_file in "$PROMPTS"/*.txt; do
+        name=$(basename "$prompt_file" .txt)
+        ref_bin="${REF_DIR}/${name}-ref.bin"
+        tgt_bin="${tgt_dir}/${name}-target.bin"
+        hoff_bin="${tgt_dir}/${name}-handoff.bin"
+
+        # target
+        if [ -f "$tgt_bin" ]; then
+            echo "  [target] $name — skip"
+        else
+            echo -n "  [target] $name — running... "
+            "$BINARY" target \
+                -m "$tgt_model" \
+                -i "$ref_bin" \
+                -o "$tgt_bin" -ngl "$NGL" > /dev/null 2>&1
+            echo "done"
+        fi
+
+        # handoff
+        if [ -f "$hoff_bin" ]; then
+            echo "  [handoff] $name — skip"
+        else
+            echo -n "  [handoff] $name — running... "
+            "$BINARY" handoff \
+                -m-ref "$REF_MODEL" \
+                -m-tgt "$tgt_model" \
+                -i "$ref_bin" \
+                -o "$hoff_bin" -ngl "$NGL" > /dev/null 2>&1
+            echo "done"
+        fi
+    done
+    echo ""
+done
+
+# --- Compare and collect results ---------------------------------------------
+
+CSV_FILE="${REF_DIR}/summary.csv"
+echo "prompt,ref_model,target_model,ref_bytes,target_bytes,n_prompt,n_gen,kl_target,top1_target,kl_handoff,top1_handoff" > "$CSV_FILE"
+
+REF_BYTES=$(model_size_bytes "$REF_MODEL")
+echo "=== Results (ref model: $(echo "$REF_BYTES" | awk '{printf "%.0f MB", $1/1048576}')) ==="
+printf "%-20s  %-15s  %7s  %7s  %5s  %10s  %8s  %10s  %8s\n" \
+    "prompt" "target" "tgt_MB" "prompt" "gen" "KL(tgt)" "top1%" "KL(hoff)" "top1%"
+printf "%-20s  %-15s  %7s  %7s  %5s  %10s  %8s  %10s  %8s\n" \
+    "--------------------" "---------------" "-------" "-------" "-----" "----------" "--------" "----------" "--------"
+
+for tgt_entry in "${TARGETS[@]}"; do
+    tgt_tag="${tgt_entry%%:*}"
+    tgt_model="${tgt_entry#*:}"
+    tgt_dir="${REF_DIR}/${tgt_tag}"
+    TGT_BYTES=$(model_size_bytes "$tgt_model")
+    TGT_MB=$(echo "$TGT_BYTES" | awk '{printf "%.0f", $1/1048576}')
+
+    for prompt_file in "$PROMPTS"/*.txt; do
+        name=$(basename "$prompt_file" .txt)
+        ref_bin="${REF_DIR}/${name}-ref.bin"
+        tgt_bin="${tgt_dir}/${name}-target.bin"
+        hoff_bin="${tgt_dir}/${name}-handoff.bin"
+
+        if [ ! -f "$tgt_bin" ] || [ ! -f "$hoff_bin" ]; then
+            continue
+        fi
+
+        tgt_out=$("$BINARY" compare -a "$ref_bin" -b "$tgt_bin" 2>/dev/null)
+        hoff_out=$("$BINARY" compare -a "$ref_bin" -b "$hoff_bin" 2>/dev/null)
+
+        tgt_kl=$(echo "$tgt_out" | grep "KL divergence:" | awk '{print $3}')
+        tgt_t1=$(echo "$tgt_out" | grep "Top-1 agree:" | awk '{print $3}')
+        hoff_kl=$(echo "$hoff_out" | grep "KL divergence:" | awk '{print $3}')
+        hoff_t1=$(echo "$hoff_out" | grep "Top-1 agree:" | awk '{print $3}')
+
+        read n_tokens_bin n_prompt <<< $(read_token_counts "$ref_bin")
+        n_gen=$((n_tokens_bin - n_prompt))
+
+        tgt_t1_num=$(echo "$tgt_t1" | tr -d '%')
+        hoff_t1_num=$(echo "$hoff_t1" | tr -d '%')
+
+        printf "%-20s  %-15s  %7s  %7s  %5s  %10s  %8s  %10s  %8s\n" \
+            "$name" "$tgt_tag" "$TGT_MB" "$n_prompt" "$n_gen" "$tgt_kl" "$tgt_t1" "$hoff_kl" "$hoff_t1"
+
+        echo "${name},${REF_TAG},${tgt_tag},${REF_BYTES},${TGT_BYTES},${n_prompt},${n_gen},${tgt_kl},${tgt_t1_num},${hoff_kl},${hoff_t1_num}" >> "$CSV_FILE"
+    done
+done
+
+echo ""
+echo "CSV written to: $CSV_FILE"
+
+# --- Decay analysis ----------------------------------------------------------
+
+DECAY_CSV="${REF_DIR}/decay.csv"
+echo "=== Decay analysis ==="
+echo "prompt,target,n_prompt,window_start,window_end,kl_target,top1_target,kl_handoff,top1_handoff" > "$DECAY_CSV"
+
+for tgt_entry in "${TARGETS[@]}"; do
+    tgt_tag="${tgt_entry%%:*}"
+    tgt_dir="${REF_DIR}/${tgt_tag}"
+
+    for prompt_file in "$PROMPTS"/*.txt; do
+        name=$(basename "$prompt_file" .txt)
+        ref_bin="${REF_DIR}/${name}-ref.bin"
+        tgt_bin="${tgt_dir}/${name}-target.bin"
+        hoff_bin="${tgt_dir}/${name}-handoff.bin"
+
+        if [ ! -f "$tgt_bin" ] || [ ! -f "$hoff_bin" ]; then
+            continue
+        fi
+
+        echo -n "  ${tgt_tag}/${name}... "
+        tmp_csv=$(mktemp)
+        "$BINARY" decay \
+            --ref "$ref_bin" --target "$tgt_bin" --handoff "$hoff_bin" \
+            --window 64 --temp "$TEMP" --csv "$tmp_csv" > /dev/null 2>&1
+
+        read n_tokens_bin n_prompt_val <<< $(read_token_counts "$ref_bin")
+
+        tail -n +2 "$tmp_csv" | while IFS= read -r line; do
+            echo "${name},${tgt_tag},${n_prompt_val},${line}" >> "$DECAY_CSV"
+        done
+        rm -f "$tmp_csv"
+        echo "done"
+    done
+done
+echo "Decay CSV written to: $DECAY_CSV"


### PR DESCRIPTION
12 test prompts across two categories:
- Short (01-08, ~200-750 tokens): code bug/explain tasks in Python, Rust, Go, C++, JS, C, Java
- Large (09-12, ~1800-2200 tokens): full codebase review tasks with ~200 lines of code in Python, Go, TypeScript, Rust

run.sh: generic experiment engine that runs ref, target, handoff, compare, and decay for all prompts across multiple target quants. Resume-friendly (skips existing .bin files). Produces summary.csv and decay.csv per reference model.

Per-model wrappers set config and source run.sh:
- run-qwen3.5-2b.sh: Q8 ref vs 6 quant targets
- run-qwen3.5-35b-a3b.sh: Q8 ref vs 6 quant targets (MoE)