### PR TITLE
kv-transfer: add result viewers, README, and technical report

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A collection of experiments related to LLM inference.
 * [llama-duo](llama-duo/) - asynchronous/distributed speculative decoding for llama3
 * [moe-inspect](moe-inspect/) - estimate per-token bytes read for GGUF models (MoE-aware)
 * [quant-sampling](quant-sampling/) - find optimal sampling temperature for quantized models via KL divergence
+* [kv-transfer](kv-transfer/) - test KV cache transfer between quantization levels

--- a/kv-transfer/README.md
+++ b/kv-transfer/README.md
@@ -1,0 +1,111 @@
+# kv-transfer — KV Cache Transfer Between Quantization Levels
+
+Tests whether processing the prompt with a high-quality model and handing off the KV cache to a lower-quality model for generation preserves output quality.
+
+## Experiment
+
+Three runs, same token sequence:
+
+1. **ref**: prompt + generation with reference model (e.g. Q8)
+2. **target**: prompt + generation with target model (e.g. Q2) — baseline for "just use the smaller model"
+3. **handoff**: prompt processed with ref model, KV cache transferred to target, generation continues with target
+
+If handoff produces logits closer to ref than target does, it means the KV cache from the better model carries useful information that helps the weaker model generate better.
+
+## How KV transfer works
+
+- llama.cpp's `llama_state_save_file` / `llama_state_load_file` saves and restores the full KV cache
+- KV cache type (default F16) is a context parameter, independent of model weight quantization
+- Both models must be the same architecture (same layer count, embedding size)
+- Both contexts use the same default F16 KV type, so the state transfers cleanly
+
+## Prerequisites
+
+- [llama.cpp](https://github.com/ggml-org/llama.cpp) built from source
+- CMake >= 3.14, C++17 compiler
+- Python 3 (for viewing results via `python3 -m http.server`)
+
+## Build
+
+```bash
+export LLAMA_CPP_DIR=/path/to/llama.cpp
+cmake -B build
+cmake --build build
+```
+
+## Subcommands
+
+```bash
+# Run reference model — generates tokens and saves logits
+./build/kv-transfer ref -m <model> -p <prompt> -n 256 --temp 0.6 -ngl 99 -o ref.bin
+
+# Run target model — replays same tokens, saves logits
+./build/kv-transfer target -m <model> -i ref.bin -o target.bin -ngl 99
+
+# Handoff — prompt with ref model, generation with target model
+./build/kv-transfer handoff -m-ref <ref_model> -m-tgt <tgt_model> -i ref.bin -o handoff.bin -ngl 99
+
+# Compare two .bin files
+./build/kv-transfer compare -a ref.bin -b target.bin
+
+# Analyze KL decay across generation position
+./build/kv-transfer decay --ref ref.bin --target target.bin --handoff handoff.bin --window 64
+```
+
+## Automated studies
+
+`run.sh` is a generic engine that runs ref, target, handoff, compare, and decay analysis for all prompts across multiple target models. Per-model wrapper scripts set the configuration and source `run.sh`:
+
+```bash
+./run-qwen3.5-2b.sh         # Qwen3.5-2B: Q8 ref vs 6 quants
+./run-qwen3.5-35b-a3b.sh    # Qwen3.5-35B-A3B (MoE): Q8 ref vs 6 quants
+```
+
+To add a new model family, create a wrapper script that sets:
+- `REF_MODEL` — path to reference GGUF
+- `REF_TAG` — tag for results directory name
+- `TARGETS` — array of `"tag:path"` pairs
+- `N_PREDICT`, `TEMP` — generation parameters
+
+Then source `run.sh`. Example:
+
+```bash
+#!/bin/bash
+REF_MODEL="$HOME/llms/MyModel-Q8.gguf"
+REF_TAG="mymodel-q8"
+TARGETS=(
+    "q2:$HOME/llms/MyModel-Q2.gguf"
+    "q4:$HOME/llms/MyModel-Q4.gguf"
+)
+N_PREDICT=512
+TEMP=0.6
+source "$(dirname "$0")/run.sh"
+```
+
+Resume-friendly — skips existing ref, target, and handoff .bin files. Summary CSV and decay CSV are always regenerated.
+
+## Results
+
+Results are organized as:
+
+```
+results/
+  view.html              # interactive bar charts (KL + top-1)
+  decay.html             # KL decay curves across generation position
+  <ref_tag>/
+    <prompt>-ref.bin     # shared across all targets
+    summary.csv          # all targets x prompts
+    decay.csv            # windowed decay analysis
+    <target_tag>/
+      <prompt>-target.bin
+      <prompt>-handoff.bin
+```
+
+Serve and view:
+
+```bash
+cd results && python3 -m http.server 8080 --bind 0.0.0.0
+# open view.html for bar charts, decay.html for decay curves
+```
+
+For detailed findings, see [TECHNICAL.md](TECHNICAL.md).

--- a/kv-transfer/TECHNICAL.md
+++ b/kv-transfer/TECHNICAL.md
@@ -1,0 +1,161 @@
+# KV Transfer: Technical Report
+
+## Motivation
+
+When running quantized LLMs, the model processes both the prompt and generates the response using the same low-precision weights. But prompt processing and generation have different characteristics:
+
+- **Prompt processing** is a one-time cost per request. It builds the KV cache that the model attends to during generation.
+- **Generation** is the iterative, latency-sensitive phase where tokens are produced one at a time.
+
+This experiment tests whether **processing the prompt with a higher-quality model and transferring the KV cache** to a lower-quality model for generation improves output quality compared to using the lower-quality model end-to-end.
+
+The practical scenario: a deployment where prompt processing can use more compute (e.g., a larger GPU, batched prefill server, or simply a higher-precision model) while generation runs on cheaper/smaller hardware.
+
+## Methodology
+
+### Three-way comparison
+
+For each prompt, we run three configurations against a reference model (Q8\_K\_XL):
+
+1. **ref** — prompt + generation with Q8 (reference). This produces the token sequence and logits we treat as ground truth.
+2. **target** — replay the same token sequence through the target model (e.g., IQ2\_XXS). Collect logits at every position. This is the "just use the smaller model" baseline.
+3. **handoff** — process the prompt with Q8, save the KV cache via `llama_state_save_file`, load it into a context created from the target model, then replay generation tokens through the target model. Prompt logits come from Q8, generation logits from the target with Q8's KV cache.
+
+### KV cache transfer mechanism
+
+- llama.cpp's `llama_state_save_file` / `llama_state_load_file` serializes the full KV cache state.
+- KV cache precision (default F16) is a **context parameter**, not tied to model weight quantization.
+- Both models use the same default F16 KV type, so the state transfers cleanly.
+- The models must share the same architecture (layer count, embedding dimensions).
+- The reference model is freed before loading the target model, so peak memory is max(ref, target), not ref+target.
+
+### Metrics
+
+- **KL divergence** — KL(ref || other) computed at each token position, averaged across all positions. Measures how different the output distribution is from the reference. Lower is better.
+- **Top-1 agreement** — percentage of positions where the most likely token matches the reference. Higher is better.
+
+### Prompts
+
+12 test prompts across two categories:
+
+**Short prompts** (200-750 tokens): code analysis tasks in Python, Rust, Go, C++, JS, C, Java. Each asks the model to find bugs or explain an algorithm.
+
+**Large prompts** (1800-2200 tokens): full codebase reviews with ~200 lines of code. Python cache store, Go worker pool, TypeScript task pipeline, Rust metrics library.
+
+## Results
+
+### Qwen3.5-2B (dense, 2.8B parameters)
+
+Reference: UD-Q8\_K\_XL (2704 MB)
+
+#### Overall KL divergence (averaged across 12 prompts)
+
+| Target | Size (MB) | KL (target) | KL (handoff) | KL ratio | Top-1% (tgt) | Top-1% (hoff) |
+|--------|----------|-------------|-------------|---------|--------------|---------------|
+| ud-iq2\_xxs | 733 | 0.884 | 0.309 | 0.35 | 72.4% | 87.7% |
+| ud-q2\_k\_xl | 922 | 0.289 | 0.102 | 0.35 | 85.5% | 93.0% |
+| ud-q3\_k\_xl | 1106 | 0.071 | 0.024 | 0.33 | 93.3% | 96.7% |
+| ud-q4\_k\_xl | 1278 | 0.022 | 0.007 | 0.32 | 96.5% | 98.2% |
+| ud-q5\_k\_xl | 1399 | 0.008 | 0.003 | 0.34 | 97.7% | 98.8% |
+| ud-q6\_k\_xl | 1778 | 0.002 | 0.001 | 0.40 | 98.8% | 99.3% |
+
+#### Prompt length effect
+
+The handoff benefit scales dramatically with prompt length:
+
+| Prompt size | Avg prompt tokens | KL ratio (iq2\_xxs) | Top-1% (hoff, iq2\_xxs) |
+|------------|------------------|--------------------|-----------------------|
+| Short (01-08) | ~443 | 0.42 | 85.2% |
+| Large (09-12) | ~2058 | 0.15 | 94.9% |
+
+With large prompts, ~80% of the total context is covered by the reference model's KV cache, so the target model's own errors are diluted.
+
+### Qwen3.5-35B-A3B (MoE, 35B total / 3B active)
+
+Reference: UD-Q8\_K\_XL (46.4 GB)
+
+The 35B MoE model shows even stronger results because the Q8 reference is much closer to "true" full precision for this architecture.
+
+| Target | Size (GB) | KL (target) | KL (handoff) | KL ratio | Top-1% (tgt) | Top-1% (hoff) |
+|--------|----------|-------------|-------------|---------|--------------|---------------|
+| ud-iq2\_xxs | 10.2 | 0.076 | 0.024 | 0.31 | 93.5% | 97.4% |
+| ud-q2\_k\_xl | 12.6 | 0.025 | 0.008 | 0.30 | 96.8% | 98.6% |
+| ud-q3\_k\_xl | 14.4 | 0.010 | 0.003 | 0.31 | 97.8% | 99.0% |
+| ud-q4\_k\_xl | 16.4 | 0.003 | 0.001 | 0.32 | 98.9% | 99.5% |
+| ud-q5\_k\_xl | 18.5 | 0.001 | 0.000 | 0.29 | 99.3% | 99.7% |
+| ud-q6\_k\_xl | 22.2 | 0.000 | 0.000 | 0.28 | 99.7% | 99.9% |
+
+## KV Cache Decay Analysis
+
+The benefit of the reference model's KV cache is expected to decay during generation, as the target model adds its own (lower-quality) KV entries.
+
+We split generation tokens into 64-token windows and compute the KL ratio (handoff/target) per window:
+
+### Qwen3.5-2B, IQ2\_XXS, averaged across all 12 prompts
+
+| Window | KL ratio | Interpretation |
+|--------|---------|----------------|
+| 0-64 | 0.50 | Strong benefit |
+| 64-128 | 0.55 | Strong benefit |
+| 128-192 | 0.68 | Moderate benefit |
+| 192-256 | 0.80 | Declining |
+| 256-320 | 0.85 | Declining |
+| 320-384 | 0.88 | Marginal |
+| 384-448 | 0.90 | Marginal |
+| 448-512 | 0.95 | Near parity |
+
+The benefit starts strong (~50% KL reduction in the first 64 tokens) and fades toward parity by the end of 512 tokens. This is consistent with the KV cache being "diluted" as new entries from the weaker model accumulate.
+
+**Note:** The decay rate varies significantly by prompt. Some prompts maintain strong benefit throughout (ratio stays ~0.6-0.7), while others show rapid decay. This may depend on how much the generation depends on long-range context from the prompt vs. recent local context.
+
+## Key Findings
+
+1. **KV transfer consistently improves generation quality.** Across all quant levels and both model families, the handoff KL is 0.28-0.40x the target KL. The improvement is not diminishing — it's roughly a constant factor across quant levels.
+
+2. **Larger prompts benefit more.** With 2000-token prompts, the KL ratio drops to ~0.15 for aggressive quants. The reference model's KV cache covers a larger fraction of total context.
+
+3. **The benefit decays during generation** but remains positive for the entire 512-token window we tested. For longer generation, the benefit will eventually reach parity.
+
+4. **MoE models show the same pattern** as dense models, with even stronger absolute quality at each quant level.
+
+## Open Questions
+
+### Practical deployment
+
+- **Latency tradeoff**: processing the prompt with a larger model is slower. Is the quality improvement worth the latency cost? This depends on the prompt:generation ratio — long prompts with short generations benefit most.
+- **State file size**: the KV state file can be large (hundreds of MB for long prompts). In a distributed setup, this transfer time matters.
+- **Mixed-precision KV**: instead of full F16 KV cache, could we quantize the KV cache itself during transfer? llama.cpp supports Q8\_0 and Q4\_0 KV types.
+
+### Further experiments
+
+- **BF16 reference**: our reference is Q8, not true BF16. Using BF16 as reference would show the full gap and potentially larger handoff benefits.
+- **Longer generation**: test with 1024-2048 generation tokens to characterize the full decay curve.
+- **Different model families**: test non-Qwen architectures (Llama, Mistral) to verify the pattern is architecture-independent.
+- **Cross-model transfer**: what happens if the reference and target are different model sizes within the same family (e.g., 35B prompt → 2B generation)?
+
+## Reproduction
+
+```bash
+# build
+export LLAMA_CPP_DIR=/path/to/llama.cpp
+cd kv-transfer
+cmake -B build && cmake --build build -j 8
+
+# run Qwen3.5-2B study
+./run-qwen3.5-2b.sh
+
+# run Qwen3.5-35B-A3B study
+./run-qwen3.5-35b-a3b.sh
+
+# view results
+cd results && python3 -m http.server 8080 --bind 0.0.0.0
+# open view.html for bar charts, decay.html for decay curves
+```
+
+## File Format
+
+The `.bin` files use a custom trace format (v3) storing:
+- Global header: magic, version, n\_vocab, n\_prompts, sampling params
+- Per-prompt sections: path string, n\_tokens, n\_prompt, token IDs, full logit vectors
+
+This format is compatible with the quant-sampling subproject's compare tool.

--- a/kv-transfer/results/decay.html
+++ b/kv-transfer/results/decay.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KV cache decay</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace; background: #f5f5f5; color: #333; padding: 16px; max-width: 1200px; }
+  h1 { font-size: 1.4em; margin-bottom: 4px; color: #111; }
+  h2 { font-size: 1.1em; margin: 24px 0 12px; color: #333; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+  .subtitle { color: #777; margin-bottom: 20px; font-size: 0.9em; }
+  .controls { margin-bottom: 16px; display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+  .controls label { font-size: 0.85em; color: #666; }
+  .controls select { background: #fff; color: #333; border: 1px solid #bbb; padding: 4px 8px; border-radius: 4px; font-size: 0.85em; }
+  .section { margin-bottom: 32px; }
+  .section p { font-size: 0.85em; color: #777; margin-bottom: 12px; }
+  .chart-container { margin: 16px 0; }
+  canvas { display: block; background: #fff; border: 1px solid #ddd; border-radius: 4px; width: 100%; }
+  .legend { display: flex; gap: 16px; font-size: 0.85em; color: #666; margin: 8px 0; flex-wrap: wrap; }
+  .legend-item { display: flex; align-items: center; gap: 5px; }
+  .legend-swatch { width: 14px; height: 3px; border-radius: 1px; }
+</style>
+</head>
+<body>
+
+<h1>KV Cache Decay Analysis</h1>
+<div class="subtitle">How the KV transfer benefit changes across generation position</div>
+
+<div class="controls">
+  <label>Data: <select id="csv-select"><option value="">Loading...</option></select></label>
+</div>
+
+<div id="content" style="display:none">
+  <div class="section">
+    <h2>KL ratio by generation position (averaged across prompts)</h2>
+    <p>KL(handoff) / KL(target). Below 1.0 = handoff is better. Approaching 1.0 = benefit fading.</p>
+    <div class="chart-container"><canvas id="chart"></canvas></div>
+    <div class="legend" id="legend"></div>
+  </div>
+</div>
+
+<script>
+const DPR = window.devicePixelRatio || 1;
+const LINE_COLORS = [
+  '#d04040','#e07840','#d0a030','#40a050','#2090a0','#2070c0','#6050c0','#a040a0','#888'
+];
+
+let allData = null;
+
+function parseCSV(text) {
+  const lines = text.trim().split('\n');
+  return lines.slice(1).map(line => {
+    const c = line.split(',');
+    // support both formats:
+    // with prompt/target/n_prompt prefix (9 cols from run.sh)
+    // without prefix (6 cols from single decay run)
+    if (c.length >= 9) {
+      return {
+        prompt: c[0], target: c[1], n_prompt: parseInt(c[2]),
+        window_start: parseInt(c[3]), window_end: parseInt(c[4]),
+        kl_target: parseFloat(c[5]), top1_target: parseFloat(c[6]),
+        kl_handoff: parseFloat(c[7]), top1_handoff: parseFloat(c[8]),
+      };
+    }
+    return {
+      prompt: 'single', target: 'target', n_prompt: 0,
+      window_start: parseInt(c[0]), window_end: parseInt(c[1]),
+      kl_target: parseFloat(c[2]), top1_target: parseFloat(c[3]),
+      kl_handoff: parseFloat(c[4]), top1_handoff: parseFloat(c[5]),
+    };
+  });
+}
+
+function getTargets(rows) {
+  const seen = new Set();
+  const result = [];
+  for (const r of rows) {
+    if (!seen.has(r.target)) { seen.add(r.target); result.push(r.target); }
+  }
+  return result;
+}
+
+function getWindows(rows) {
+  const seen = new Set();
+  const result = [];
+  for (const r of rows) {
+    const key = `${r.window_start}-${r.window_end}`;
+    if (!seen.has(key)) { seen.add(key); result.push({ start: r.window_start, end: r.window_end }); }
+  }
+  return result.sort((a, b) => a.start - b.start);
+}
+
+function aggregate(rows) {
+  // average across prompts: for each (target, window) -> mean values
+  const key = (r) => `${r.target}|${r.window_start}`;
+  const groups = {};
+  for (const r of rows) {
+    const k = key(r);
+    if (!groups[k]) groups[k] = { ...r, _count: 1 };
+    else {
+      groups[k].kl_target += r.kl_target;
+      groups[k].kl_handoff += r.kl_handoff;
+      groups[k].top1_target += r.top1_target;
+      groups[k].top1_handoff += r.top1_handoff;
+      groups[k]._count++;
+    }
+  }
+  const result = [];
+  for (const g of Object.values(groups)) {
+    result.push({
+      ...g,
+      kl_target: g.kl_target / g._count,
+      kl_handoff: g.kl_handoff / g._count,
+      top1_target: g.top1_target / g._count,
+      top1_handoff: g.top1_handoff / g._count,
+    });
+  }
+  return result;
+}
+
+function drawChart() {
+  if (!allData) return;
+
+  const metric = 'kl_ratio';
+  const agg = aggregate(allData);
+  const targets = getTargets(agg);
+  const windows = getWindows(agg);
+
+  // build series
+  const series = [];
+  for (const tgt of targets) {
+    const tgtRows = agg.filter(r => r.target === tgt);
+    const points = windows.map(w => {
+      const r = tgtRows.find(r => r.window_start === w.start);
+      if (!r) return null;
+      if (metric === 'kl_ratio') return r.kl_target > 0 ? r.kl_handoff / r.kl_target : 0;
+      if (metric === 'kl_both') return { v1: r.kl_target, v2: r.kl_handoff };
+      if (metric === 'top1_both') return { v1: r.top1_target, v2: r.top1_handoff };
+      return 0;
+    });
+    series.push({ name: tgt, points });
+  }
+
+
+  const canvas = document.getElementById('chart');
+  const W = Math.min(900, window.innerWidth - 32);
+  const H = 400;
+  canvas.style.width = W + 'px'; canvas.style.height = H + 'px';
+  canvas.width = W * DPR; canvas.height = H * DPR;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(DPR, DPR);
+  ctx.clearRect(0, 0, W, H);
+
+  const pad = { top: 20, right: 20, bottom: 45, left: 55 };
+  const cw = W - pad.left - pad.right;
+  const ch = H - pad.top - pad.bottom;
+
+  // compute y range
+  let yMin, yMax;
+  if (metric === 'kl_ratio') {
+    const allVals = series.flatMap(s => s.points.filter(p => p !== null));
+    yMin = 0;
+    yMax = Math.min(Math.max(...allVals) * 1.1, 1.5);
+  } else {
+    const allVals = series.flatMap(s => s.points.filter(p => p !== null).flatMap(p => [p.v1, p.v2]));
+    yMin = 0;
+    yMax = Math.max(...allVals) * 1.1;
+  }
+
+  const toX = (i) => pad.left + (i / (windows.length - 1)) * cw;
+  const toY = (v) => pad.top + ch - ((v - yMin) / (yMax - yMin)) * ch;
+
+  // grid
+  ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
+  ctx.fillStyle = '#bbb'; ctx.font = '12px monospace';
+  ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+  const nGridY = 5;
+  for (let i = 0; i <= nGridY; i++) {
+    const v = yMin + (yMax - yMin) * i / nGridY;
+    const y = toY(v);
+    ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(W - pad.right, y); ctx.stroke();
+    ctx.fillText(metric === 'top1_both' ? v.toFixed(0) + '%' : v.toFixed(2), pad.left - 6, y);
+  }
+
+  // reference line at 1.0 for ratio
+  if (metric === 'kl_ratio' && yMax >= 1.0) {
+    const y1 = toY(1.0);
+    ctx.strokeStyle = '#999'; ctx.lineWidth = 1; ctx.setLineDash([5, 5]);
+    ctx.beginPath(); ctx.moveTo(pad.left, y1); ctx.lineTo(W - pad.right, y1); ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = '#999'; ctx.textAlign = 'left';
+    ctx.fillText('1.0 (no benefit)', W - pad.right - 100, y1 - 8);
+  }
+
+  // x labels
+  ctx.fillStyle = '#bbb'; ctx.font = '11px monospace'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+  for (let i = 0; i < windows.length; i++) {
+    if (i % 2 === 0 || windows.length <= 10) {
+      ctx.fillText(`${windows[i].start}`, toX(i), H - pad.bottom + 6);
+    }
+  }
+  ctx.fillText('generation token offset', pad.left + cw / 2, H - 8);
+
+  // draw lines
+  function drawLine(points, color, dashed) {
+    ctx.strokeStyle = color; ctx.lineWidth = 2.5;
+    ctx.setLineDash(dashed ? [6, 4] : []);
+    ctx.beginPath();
+    let started = false;
+    for (let i = 0; i < points.length; i++) {
+      if (points[i] === null) continue;
+      const x = toX(i);
+      const y = toY(points[i]);
+      if (!started) { ctx.moveTo(x, y); started = true; }
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // dots
+    ctx.fillStyle = color;
+    for (let i = 0; i < points.length; i++) {
+      if (points[i] === null) continue;
+      ctx.beginPath(); ctx.arc(toX(i), toY(points[i]), 3, 0, Math.PI * 2); ctx.fill();
+    }
+  }
+
+  for (let si = 0; si < series.length; si++) {
+    const color = LINE_COLORS[si % LINE_COLORS.length];
+    drawLine(series[si].points, color, false);
+  }
+
+  // legend
+  const legendDiv = document.getElementById('legend');
+  legendDiv.innerHTML = targets.map((t, i) =>
+    `<div class="legend-item"><div class="legend-swatch" style="background:${LINE_COLORS[i % LINE_COLORS.length]}"></div>${t}</div>`
+  ).join('');
+}
+
+async function init() {
+  const html = await (await fetch('./')).text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const links = [...doc.querySelectorAll('a')].map(a => a.getAttribute('href'));
+
+  const csvFiles = [];
+  const dirs = links.filter(h => h && h.endsWith('/') && h !== '../');
+  for (const dir of dirs) {
+    try {
+      const subHtml = await (await fetch(dir)).text();
+      const subDoc = parser.parseFromString(subHtml, 'text/html');
+      const subLinks = [...subDoc.querySelectorAll('a')].map(a => a.getAttribute('href'));
+      if (subLinks.includes('decay.csv')) csvFiles.push(dir + 'decay.csv');
+    } catch (e) {}
+  }
+  if (links.includes('decay.csv')) csvFiles.unshift('decay.csv');
+
+  const select = document.getElementById('csv-select');
+  select.innerHTML = '';
+  if (csvFiles.length === 0) { select.innerHTML = '<option>No decay.csv found</option>'; return; }
+  for (const f of csvFiles) {
+    const opt = document.createElement('option');
+    opt.value = f; opt.textContent = f; select.appendChild(opt);
+  }
+
+  const load = async (url) => {
+    const text = await (await fetch(url)).text();
+    allData = parseCSV(text);
+    document.getElementById('content').style.display = 'block';
+    drawChart();
+  };
+
+  select.addEventListener('change', () => load(select.value));
+  load(csvFiles[0]);
+}
+
+init();
+</script>
+</body>
+</html>

--- a/kv-transfer/results/view.html
+++ b/kv-transfer/results/view.html
@@ -1,0 +1,492 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>kv-transfer results</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace; background: #f5f5f5; color: #333; padding: 16px; max-width: 1200px; }
+  h1 { font-size: 1.4em; margin-bottom: 4px; color: #111; }
+  h2 { font-size: 1.1em; margin: 24px 0 12px; color: #333; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+  .subtitle { color: #777; margin-bottom: 20px; font-size: 0.9em; }
+  .controls { margin-bottom: 16px; }
+  .controls label { font-size: 0.85em; color: #666; }
+  .controls select { background: #fff; color: #333; border: 1px solid #bbb; padding: 4px 8px; border-radius: 4px; font-size: 0.85em; }
+  .section { margin-bottom: 32px; }
+  .section p { font-size: 0.85em; color: #777; margin-bottom: 12px; }
+  table { border-collapse: collapse; font-size: 0.82em; width: 100%; margin-bottom: 16px; overflow-x: auto; display: block; }
+  th, td { padding: 5px 10px; text-align: right; white-space: nowrap; }
+  th { color: #555; border-bottom: 2px solid #ccc; }
+  th:first-child, td:first-child { text-align: left; }
+  td { border-bottom: 1px solid #e0e0e0; }
+  .chart-container { margin: 16px 0; position: relative; }
+  canvas { display: block; background: #fff; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; width: 100%; }
+  .legend { display: flex; gap: 20px; font-size: 0.85em; color: #666; margin: 8px 0; flex-wrap: wrap; }
+  .legend-item { display: flex; align-items: center; gap: 5px; }
+  .legend-swatch { width: 14px; height: 14px; border-radius: 2px; }
+  .hint { font-size: 0.8em; color: #999; margin-top: 4px; }
+</style>
+</head>
+<body>
+
+<h1>KV Transfer Results</h1>
+<div class="subtitle" id="subtitle">Loading...</div>
+
+<div class="controls">
+  <label>Data: <select id="csv-select"><option value="">Loading...</option></select></label>
+</div>
+
+<div id="content" style="display:none">
+
+  <div class="section">
+    <h2>KL Divergence (averaged across prompts, log scale, lower is better)</h2>
+    <div class="chart-container">
+      <canvas id="chart-kl"></canvas>
+    </div>
+    <div class="legend">
+      <div class="legend-item"><div class="legend-swatch" style="background:#d04040"></div>Target (no transfer)</div>
+      <div class="legend-item"><div class="legend-swatch" style="background:#2070c0"></div>Handoff (KV transfer)</div>
+    </div>
+    <div class="hint">Tap a bar to compare it against all others. Tap again to deselect.</div>
+  </div>
+
+  <div class="section">
+    <h2>Top-1 Agreement (averaged across prompts, higher is better)</h2>
+    <div class="chart-container">
+      <canvas id="chart-top1"></canvas>
+    </div>
+    <div class="legend">
+      <div class="legend-item"><div class="legend-swatch" style="background:#d04040"></div>Target (no transfer)</div>
+      <div class="legend-item"><div class="legend-swatch" style="background:#2070c0"></div>Handoff (KV transfer)</div>
+    </div>
+    <div class="hint">Tap a bar to compare.</div>
+  </div>
+
+  <div class="section">
+    <h2>Per-Prompt Consistency (each dot = one prompt, log scale)</h2>
+    <p>X = KL(target), Y = KL(handoff). Points below the diagonal improved with KV transfer. A tight band shows the effect is consistent across prompts.</p>
+    <div class="chart-container">
+      <canvas id="chart-scatter"></canvas>
+    </div>
+    <div id="scatter-legend" class="legend"></div>
+    <div class="hint">Hover over a point to see prompt details.</div>
+    <div id="scatter-tooltip" style="font-size:0.82em;color:#555;min-height:1.2em;margin-top:4px;"></div>
+  </div>
+
+
+</div>
+
+<script>
+const QUANT_ORDER = ['iq2_xxs','q2_k_xl','iq3_xxs','q3_k_xl','iq4_xs','q4_k_xl','q5_k_xl','q6_k_xl','q8_k_xl'];
+const COLORS = { target: '#d04040', handoff: '#2070c0' };
+const COLORS_DIM = { target: '#e8b0b0', handoff: '#b0c8e0' };
+const DPR = window.devicePixelRatio || 1;
+
+function sortQuants(tags) {
+  return [...tags].sort((a, b) => {
+    const ai = QUANT_ORDER.indexOf(a);
+    const bi = QUANT_ORDER.indexOf(b);
+    return (ai < 0 ? 999 : ai) - (bi < 0 ? 999 : bi);
+  });
+}
+
+function parseCSV(text) {
+  const lines = text.trim().split('\n');
+  return lines.slice(1).map(line => {
+    const c = line.split(',');
+    return {
+      prompt: c[0], ref_model: c[1], target_model: c[2],
+      ref_bytes: parseInt(c[3]), target_bytes: parseInt(c[4]),
+      n_prompt: parseInt(c[5]), n_gen: parseInt(c[6]),
+      kl_target: parseFloat(c[7]), top1_target: parseFloat(c[8]),
+      kl_handoff: parseFloat(c[9]), top1_handoff: parseFloat(c[10]),
+    };
+  });
+}
+
+function aggregate(rows) {
+  const byQuant = {};
+  for (const r of rows) {
+    const q = r.target_model;
+    if (!byQuant[q]) byQuant[q] = [];
+    byQuant[q].push(r);
+  }
+  const quants = sortQuants(Object.keys(byQuant));
+  const stats = {};
+  for (const q of quants) {
+    const rs = byQuant[q];
+    const n = rs.length;
+    stats[q] = {
+      kl_target:    rs.reduce((s, r) => s + r.kl_target, 0) / n,
+      kl_handoff:   rs.reduce((s, r) => s + r.kl_handoff, 0) / n,
+      top1_target:  rs.reduce((s, r) => s + r.top1_target, 0) / n,
+      top1_handoff: rs.reduce((s, r) => s + r.top1_handoff, 0) / n,
+    };
+  }
+  return { quants, stats };
+}
+
+const charts = {};
+
+function initChart(id) {
+  charts[id] = { bars: [], selected: null, quants: null, stats: null, key1: null, key2: null, logScale: false };
+}
+
+function sizeCanvas(canvas, quants) {
+  const rowH = 52;
+  const W = Math.min(900, window.innerWidth - 32);
+  const H = quants.length * rowH + 40;
+  canvas.style.width = W + 'px';
+  canvas.style.height = H + 'px';
+  canvas.width = W * DPR;
+  canvas.height = H * DPR;
+}
+
+function drawChart(id) {
+  const c = charts[id];
+  const { quants, stats, key1, key2, logScale, selected } = c;
+  const canvas = document.getElementById(id);
+  sizeCanvas(canvas, quants);
+  const ctx = canvas.getContext('2d');
+  ctx.scale(DPR, DPR);
+  const W = canvas.width / DPR;
+  const H = canvas.height / DPR;
+  const pad = { top: 10, right: 80, bottom: 30, left: 90 };
+  const cw = W - pad.left - pad.right;
+  const ch = H - pad.top - pad.bottom;
+  ctx.clearRect(0, 0, W, H);
+
+  const vals1 = quants.map(q => stats[q][key1]);
+  const vals2 = quants.map(q => stats[q][key2]);
+  const allVals = [...vals1, ...vals2].filter(v => v > 0);
+
+  let toX, baseline;
+
+  if (logScale) {
+    const logMin = Math.floor(Math.log10(Math.min(...allVals)));
+    const logMax = Math.ceil(Math.log10(Math.max(...allVals) * 1.2));
+    const minVal = Math.pow(10, logMin);
+    const maxVal = Math.pow(10, logMax);
+    toX = (v) => pad.left + ((Math.log10(Math.max(v, minVal)) - logMin) / (logMax - logMin)) * cw;
+    baseline = pad.left;
+
+    ctx.fillStyle = '#bbb'; ctx.font = '12px monospace'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    for (let p = logMin; p <= logMax; p++) {
+      const v = Math.pow(10, p);
+      const x = toX(v);
+      ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
+      ctx.beginPath(); ctx.moveTo(x, pad.top); ctx.lineTo(x, H - pad.bottom); ctx.stroke();
+      ctx.fillText(v >= 1 ? v.toFixed(0) : v.toFixed(Math.abs(p)), x, H - pad.bottom + 6);
+      for (const m of [2, 5]) {
+        const vm = v * m;
+        if (vm > maxVal) break;
+        ctx.strokeStyle = '#eee'; ctx.beginPath();
+        ctx.moveTo(toX(vm), pad.top); ctx.lineTo(toX(vm), H - pad.bottom); ctx.stroke();
+      }
+    }
+  } else {
+    const maxVal = Math.ceil(Math.max(...allVals) / 10) * 10;
+    toX = (v) => pad.left + (v / maxVal) * cw;
+    baseline = pad.left;
+
+    ctx.fillStyle = '#bbb'; ctx.font = '12px monospace'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    for (let i = 0; i <= 5; i++) {
+      const v = maxVal * i / 5;
+      const x = toX(v);
+      ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
+      ctx.beginPath(); ctx.moveTo(x, pad.top); ctx.lineTo(x, H - pad.bottom); ctx.stroke();
+      ctx.fillText(v.toFixed(0) + '%', x, H - pad.bottom + 6);
+    }
+  }
+
+  const rowH = ch / quants.length;
+  const barH = rowH * 0.3;
+  const barGap = 2;
+
+  let selVal = null;
+  if (selected !== null) {
+    const si = Math.floor(selected / 2);
+    const st = selected % 2;
+    selVal = st === 0 ? vals1[si] : vals2[si];
+  }
+
+  c.bars = [];
+
+  for (let i = 0; i < quants.length; i++) {
+    const y0 = pad.top + i * rowH;
+
+    for (let t = 0; t < 2; t++) {
+      const val = t === 0 ? vals1[i] : vals2[i];
+      const barIdx = i * 2 + t;
+      const isSelected = selected === barIdx;
+      const isDimmed = selected !== null && !isSelected;
+
+      const by = t === 0 ? y0 + (rowH / 2 - barH - barGap) : y0 + (rowH / 2 + barGap);
+      const bw = toX(val) - baseline;
+
+      const baseColor = t === 0 ? COLORS.target : COLORS.handoff;
+      const dimColor = t === 0 ? COLORS_DIM.target : COLORS_DIM.handoff;
+      ctx.fillStyle = isDimmed ? dimColor : baseColor;
+      if (isSelected) {
+        ctx.shadowColor = baseColor;
+        ctx.shadowBlur = 6;
+      }
+      ctx.fillRect(baseline, by, bw, barH);
+      ctx.shadowBlur = 0;
+
+      c.bars.push({ x: baseline, y: by, w: bw, h: barH, val, idx: barIdx });
+
+      // label at end of bar
+      ctx.font = '12px monospace'; ctx.textBaseline = 'middle';
+      ctx.textAlign = 'left';
+      const labelX = baseline + bw + 6;
+      const labelY = by + barH / 2;
+
+      if (selected !== null && !isSelected && selVal > 0) {
+        const diff = ((val - selVal) / selVal) * 100;
+        const sign = diff >= 0 ? '+' : '';
+        ctx.fillStyle = '#555';
+        ctx.fillText(`${sign}${diff.toFixed(0)}%`, labelX, labelY);
+      } else {
+        ctx.fillStyle = '#777';
+        const label = logScale ? val.toFixed(3) : val.toFixed(1) + '%';
+        ctx.fillText(label, labelX, labelY);
+      }
+    }
+
+    // quant label on left
+    ctx.fillStyle = '#333'; ctx.font = '13px monospace';
+    ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+    ctx.fillText(quants[i], pad.left - 8, y0 + rowH / 2);
+  }
+}
+
+function handleClick(id, e) {
+  const c = charts[id];
+  const canvas = document.getElementById(id);
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX - rect.left) * DPR;
+  const my = (e.clientY - rect.top) * DPR;
+
+  // scale to logical coords
+  const lx = mx / DPR;
+  const ly = my / DPR;
+
+  // expand hit area vertically for easier tapping
+  let clicked = null;
+  for (const bar of c.bars) {
+    const hitPad = 6;
+    if (lx >= bar.x && lx <= bar.x + bar.w + 60 &&
+        ly >= bar.y - hitPad && ly <= bar.y + bar.h + hitPad) {
+      clicked = bar.idx;
+      break;
+    }
+  }
+
+  c.selected = (clicked === c.selected) ? null : clicked;
+  drawChart(id);
+}
+
+function setupChart(id, quants, stats, key1, key2, logScale) {
+  initChart(id);
+  const c = charts[id];
+  c.quants = quants; c.stats = stats; c.key1 = key1; c.key2 = key2; c.logScale = logScale;
+
+  // remove old listeners by replacing element, then draw on the new one
+  const canvas = document.getElementById(id);
+  const newCanvas = canvas.cloneNode(true);
+  canvas.parentNode.replaceChild(newCanvas, canvas);
+  newCanvas.addEventListener('click', (e) => handleClick(id, e));
+  newCanvas.addEventListener('touchend', (e) => {
+    e.preventDefault();
+    const touch = e.changedTouches[0];
+    handleClick(id, { clientX: touch.clientX, clientY: touch.clientY });
+  });
+
+  drawChart(id);
+}
+
+/* ── scatter plot ─────────────────────────────────────────── */
+
+const QUANT_COLORS = [
+  '#e03030', '#e07020', '#c0a020', '#40a040', '#2080c0', '#6050d0', '#a040a0', '#666', '#333'
+];
+
+function quantColor(quants, q) {
+  return QUANT_COLORS[quants.indexOf(q) % QUANT_COLORS.length];
+}
+
+const scatter = { points: [], rows: null, quants: null };
+
+function drawScatter(rows, quants) {
+  scatter.rows = rows;
+  scatter.quants = quants;
+
+  const canvas = document.getElementById('chart-scatter');
+  const size = Math.min(600, window.innerWidth - 32);
+  canvas.style.width = size + 'px';
+  canvas.style.height = size + 'px';
+  canvas.width = size * DPR;
+  canvas.height = size * DPR;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(DPR, DPR);
+  const W = size, H = size;
+  const pad = { top: 16, right: 16, bottom: 40, left: 52 };
+  const cw = W - pad.left - pad.right;
+  const ch = H - pad.top - pad.bottom;
+  ctx.clearRect(0, 0, W, H);
+
+  // compute log bounds across all points
+  const allKL = rows.flatMap(r => [r.kl_target, r.kl_handoff]).filter(v => v > 0);
+  const logMin = Math.floor(Math.log10(Math.min(...allKL)) * 2) / 2;
+  const logMax = Math.ceil(Math.log10(Math.max(...allKL)) * 2) / 2;
+  const toX = v => pad.left + ((Math.log10(v) - logMin) / (logMax - logMin)) * cw;
+  const toY = v => pad.top + ch - ((Math.log10(v) - logMin) / (logMax - logMin)) * ch;
+
+  // grid lines
+  ctx.strokeStyle = '#e0e0e0'; ctx.lineWidth = 0.5;
+  ctx.fillStyle = '#aaa'; ctx.font = '11px monospace'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+  for (let p = Math.ceil(logMin); p <= Math.floor(logMax); p++) {
+    const v = Math.pow(10, p);
+    const x = toX(v), y = toY(v);
+    ctx.beginPath(); ctx.moveTo(x, pad.top); ctx.lineTo(x, H - pad.bottom); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(W - pad.right, y); ctx.stroke();
+    const label = v >= 1 ? v.toFixed(0) : v < 0.01 ? v.toExponential(0) : v.toFixed(Math.abs(p));
+    ctx.fillText(label, x, H - pad.bottom + 6);
+    ctx.save(); ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+    ctx.fillText(label, pad.left - 6, y);
+    ctx.restore();
+  }
+
+  // axis labels
+  ctx.fillStyle = '#777'; ctx.font = '12px monospace';
+  ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+  ctx.fillText('KL(target)', pad.left + cw / 2, H - 12);
+  ctx.save();
+  ctx.translate(14, pad.top + ch / 2);
+  ctx.rotate(-Math.PI / 2);
+  ctx.textBaseline = 'middle'; ctx.textAlign = 'center';
+  ctx.fillText('KL(handoff)', 0, 0);
+  ctx.restore();
+
+  // diagonal y = x
+  ctx.strokeStyle = '#bbb'; ctx.lineWidth = 1; ctx.setLineDash([4, 4]);
+  ctx.beginPath(); ctx.moveTo(toX(Math.pow(10, logMin)), toY(Math.pow(10, logMin)));
+  ctx.lineTo(toX(Math.pow(10, logMax)), toY(Math.pow(10, logMax))); ctx.stroke();
+  ctx.setLineDash([]);
+
+  // draw points — circles for short prompts, squares for long
+  scatter.points = [];
+  const R = 5;
+  const isLong = (name) => name.match(/^(09|10|11|12)_/) || parseInt(name) >= 9;
+  for (const r of rows) {
+    if (r.kl_target <= 0 || r.kl_handoff <= 0) continue;
+    const x = toX(r.kl_target), y = toY(r.kl_handoff);
+    const color = quantColor(quants, r.target_model);
+    const long = isLong(r.prompt);
+    ctx.fillStyle = color;
+    ctx.globalAlpha = 0.75;
+    if (long) {
+      ctx.fillRect(x - R, y - R, R * 2, R * 2);
+    } else {
+      ctx.beginPath(); ctx.arc(x, y, R, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.globalAlpha = 1.0;
+    ctx.strokeStyle = color; ctx.lineWidth = 1;
+    if (long) {
+      ctx.strokeRect(x - R, y - R, R * 2, R * 2);
+    } else {
+      ctx.beginPath(); ctx.arc(x, y, R, 0, Math.PI * 2); ctx.stroke();
+    }
+    scatter.points.push({ x, y, r: R + 3, row: r });
+  }
+
+  // legend — quant colors + shape key
+  const legendEl = document.getElementById('scatter-legend');
+  const colorLegend = quants.map(q =>
+    `<div class="legend-item"><div class="legend-swatch" style="background:${quantColor(quants, q)}"></div>${q}</div>`
+  ).join('');
+  const shapeLegend =
+    `<div class="legend-item"><div class="legend-swatch" style="background:#999;border-radius:50%"></div>short prompt</div>` +
+    `<div class="legend-item"><div class="legend-swatch" style="background:#999;border-radius:0"></div>long prompt</div>`;
+  legendEl.innerHTML = colorLegend + shapeLegend;
+}
+
+function scatterHit(e) {
+  const canvas = document.getElementById('chart-scatter');
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX - rect.left);
+  const my = (e.clientY - rect.top);
+  for (const p of scatter.points) {
+    const dx = mx - p.x, dy = my - p.y;
+    if (dx * dx + dy * dy <= p.r * p.r) return p.row;
+  }
+  return null;
+}
+
+function initScatterEvents() {
+  const canvas = document.getElementById('chart-scatter');
+  const tip = document.getElementById('scatter-tooltip');
+  const handler = (e) => {
+    const r = scatterHit(e);
+    if (r) {
+      const ratio = (r.kl_handoff / r.kl_target).toFixed(2);
+      tip.textContent = `${r.prompt} [${r.target_model}] — target: ${r.kl_target.toFixed(3)}, handoff: ${r.kl_handoff.toFixed(3)}, ratio: ${ratio}`;
+    } else {
+      tip.textContent = '';
+    }
+  };
+  canvas.addEventListener('mousemove', handler);
+  canvas.addEventListener('touchstart', (e) => { e.preventDefault(); handler({ clientX: e.touches[0].clientX, clientY: e.touches[0].clientY }); });
+}
+
+function render(rows) {
+  const { quants, stats } = aggregate(rows);
+  setupChart('chart-kl', quants, stats, 'kl_target', 'kl_handoff', true);
+  setupChart('chart-top1', quants, stats, 'top1_target', 'top1_handoff', false);
+  drawScatter(rows, quants);
+  initScatterEvents();
+}
+
+async function init() {
+  const html = await (await fetch('./')).text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const links = [...doc.querySelectorAll('a')].map(a => a.getAttribute('href'));
+
+  const csvFiles = [];
+  const dirs = links.filter(h => h && h.endsWith('/') && h !== '../');
+  for (const dir of dirs) {
+    try {
+      const subHtml = await (await fetch(dir)).text();
+      const subDoc = parser.parseFromString(subHtml, 'text/html');
+      const subLinks = [...subDoc.querySelectorAll('a')].map(a => a.getAttribute('href'));
+      if (subLinks.includes('summary.csv')) csvFiles.push(dir + 'summary.csv');
+    } catch (e) {}
+  }
+  if (links.includes('summary.csv')) csvFiles.unshift('summary.csv');
+
+  const select = document.getElementById('csv-select');
+  select.innerHTML = '';
+  if (csvFiles.length === 0) { select.innerHTML = '<option>No data found</option>'; return; }
+  for (const f of csvFiles) {
+    const opt = document.createElement('option');
+    opt.value = f; opt.textContent = f; select.appendChild(opt);
+  }
+
+  const load = async (url) => {
+    const text = await (await fetch(url)).text();
+    document.getElementById('subtitle').textContent = url;
+    document.getElementById('content').style.display = 'block';
+    render(parseCSV(text));
+  };
+
+  select.addEventListener('change', () => load(select.value));
+  load(csvFiles[0]);
+}
+
+init();
+</script>
+</body>
+</html>


### PR DESCRIPTION
HTML viewers (no dependencies, canvas-based):
- view.html: aggregated KL divergence + top-1 bar charts, per-prompt consistency scatter plot with shape encoding for prompt length
- decay.html: KL decay curves across generation position

Documentation:
- README.md: build instructions, subcommand reference, automated study workflow, results directory layout
- TECHNICAL.md: methodology, metrics, findings for Qwen3.5-2B and Qwen3.5-35B-A3B, decay analysis, open questions
- Root README.md: add kv-transfer to project listing

Results CSVs excluded — will be regenerated from a fresh run to verify reproducibility.